### PR TITLE
configure pytest.ini to include `test.py` files inside plugins

### DIFF
--- a/brainscore_language/plugins/wikitext_next_word_prediction/test.py
+++ b/brainscore_language/plugins/wikitext_next_word_prediction/test.py
@@ -10,7 +10,7 @@ class TestData:
         assert data[1] == ' = Robert Boulter = \n'
 
     def test_length(self):
-        data = load_dataset('wikitext-2')
+        data = load_dataset('wikitext-2/test')
         assert len(data) == 4358
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# include plugins test.py files, not just test_*.py
+python_files = test*.py


### PR DESCRIPTION
before, `test.py` files were not detected by pytest because the default naming is `test_*.py`

also fix wikitext test