### PR TITLE
add more type hints; organize ArtificialSubject

### DIFF
--- a/brainscore_language/__init__.py
+++ b/brainscore_language/__init__.py
@@ -1,5 +1,5 @@
 from brainscore_core.benchmarks import Benchmark
-from brainscore_core.metrics import Score
+from brainscore_core.metrics import Score, Metric
 from brainscore_language.artificial_subject import ArtificialSubject
 
 datasets = {}
@@ -15,21 +15,21 @@ def load_dataset(identifier):
     return datasets[identifier]()
 
 
-def load_metric(identifier):
+def load_metric(identifier) -> Metric:
     # imports to load plugins until plugin system is implemented
     from brainscore_language.plugins.wikitext_next_word_prediction import metric
 
     return metrics[identifier]()
 
 
-def load_benchmark(identifier):
+def load_benchmark(identifier) -> Benchmark:
     # imports to load plugins until plugin system is implemented
     from brainscore_language.plugins.wikitext_next_word_prediction import benchmark
 
     return benchmarks[identifier]()
 
 
-def load_model(identifier):
+def load_model(identifier) -> ArtificialSubject:
     return models[identifier]
 
 

--- a/brainscore_language/artificial_subject.py
+++ b/brainscore_language/artificial_subject.py
@@ -1,7 +1,24 @@
 from enum import Enum
 
+from brainscore_core import DataAssembly
+
+
 class ArtificialSubject:
-    # TODO @EvLab: do these make sense?
+    def identifier(self) -> str:
+        """
+        The unique identifier for this model.
+        :return: e.g. 'glove', or 'distilgpt2'
+        """
+        raise NotImplementedError()
+
+    Task = Enum('Task', " ".join(['next_word', 'surprisal']))
+    """
+    task to perform
+    """
+
+    def perform_task(self, task: Task):
+        raise NotImplementedError()
+
     RecordingTarget = Enum('RecordingTarget', " ".join([
         'language_system',
         'language_system_left_hemisphere',
@@ -12,33 +29,14 @@ class ArtificialSubject:
     """
 
     RecordingType = Enum('RecordingTarget', " ".join([
-        'fMRI',
+        'exact', 'fMRI',
     ]))
     """
     method of recording
     """
 
-    # TODO @Dhaval, @Jim: how do we specify this more accurately for what exactly the outputs are expected to be?
-    #  Just more documentation? Also double-check with PIs that these are sufficient for a first round
-    Task = Enum('Task', " ".join(['next_word', 'surprisal']))
-    """
-    task to perform
-    """
-
-    def identifier(self) -> str:
-        """
-        The unique identifier for this model.
-        :return: e.g. 'glove', or 'distilgpt2'
-        """
+    def get_representations(self, recording_target: RecordingTarget, recording_type: RecordingType):
         raise NotImplementedError()
 
-    def digest_text(self, stimuli):
-        raise NotImplementedError()
-
-    # TODO @Dhaval, @Jim, @EvLab: conceptual decision on how we want layer-to-region commitments to happen in the
-    #  standard wrapper -- search for best layer on public data?
-    def get_representations(self, recording_target: RecordingTarget):
-        raise NotImplementedError()
-
-    def perform_task(self, task: Task):
+    def digest_text(self, stimuli) -> DataAssembly:
         raise NotImplementedError()

--- a/brainscore_language/plugins/wikitext_next_word_prediction/benchmark.py
+++ b/brainscore_language/plugins/wikitext_next_word_prediction/benchmark.py
@@ -3,6 +3,7 @@ import re
 import string
 
 from brainscore_core.benchmarks import BenchmarkBase
+from brainscore_core.metrics import Score
 from brainscore_language import load_dataset, load_metric, benchmarks
 from brainscore_language.artificial_subject import ArtificialSubject
 
@@ -28,7 +29,7 @@ class Merity2016nextwordAccuracy(BenchmarkBase):
         self.data = load_dataset('wikitext-2/test')
         self.metric = load_metric('accuracy')
 
-    def __call__(self, candidate: ArtificialSubject):
+    def __call__(self, candidate: ArtificialSubject) -> Score:
         candidate.perform_task(ArtificialSubject.Task.next_word)
         contexts, targets = self.build_contexts()
         predictions = candidate.digest_text(contexts)


### PR DESCRIPTION
following feedback from @evandez, I went through and made sure we had type hints in the high-level places.

I also re-organized `ArtificialSubject` slightly so that enums are next to the functions they correspond to rather than at a separate place at the top