### PR TITLE
rename subject's `context` -> `stimulus`

### DIFF
--- a/brainscore_language/artificial_subject.py
+++ b/brainscore_language/artificial_subject.py
@@ -20,7 +20,7 @@ class ArtificialSubject:
         next_word = 'next_word'
         """ 
         Predict the next word from the preceding context. Output a :class:`~brainio.assemblies.BehavioralAssembly` with 
-        next-word predictions as the values and preceding context in the `context` coordinate.
+        next-word predictions as the values and preceding stimulus in the `stimulus` coordinate.
 
         Example:
 
@@ -32,7 +32,7 @@ class ArtificialSubject:
                         array(['fox']), # the actual next word
                         Coordinates:
                           * presentation  (presentation) MultiIndex
-                          - context       (presentation) object 'the quick brown'
+                          - stimulus      (presentation) object 'the quick brown'
                           - stimulus_id   (presentation) int64 0}
 
         Example:
@@ -45,7 +45,7 @@ class ArtificialSubject:
                         array(['fox', 'over', 'dog']), # the actual next words
                         Coordinates:
                           * presentation  (presentation) MultiIndex
-                          - context       (presentation) object 'the quick brown' 'fox jumps', 'over the lazy'
+                          - stimulus      (presentation) object 'the quick brown' 'fox jumps', 'over the lazy'
                           - stimulus_id   (presentation) int64 0 1 2}
         """
 
@@ -53,7 +53,7 @@ class ArtificialSubject:
         """ 
         Output how long it took to read a given text, in milliseconds. 
         Output a :class:`~brainio.assemblies.BehavioralAssembly` with reading times in milliseconds as the values and 
-        text in the `context` coordinate.
+        text in the `stimulus` coordinate.
 
         Example:
 
@@ -65,7 +65,7 @@ class ArtificialSubject:
                         array([329.15]), # reading time in milliseconds
                         Coordinates:
                           * presentation  (presentation) MultiIndex
-                          - context       (presentation) object 'the quick brown'
+                          - stimulus      (presentation) object 'the quick brown'
                           - stimulus_id   (presentation) int64 0}
 
         Example:
@@ -78,7 +78,7 @@ class ArtificialSubject:
                         array([329.15, 337.53, 341.13]), # reading times in milliseconds
                         Coordinates:
                           * presentation  (presentation) MultiIndex
-                          - context       (presentation) object 'the quick brown' 'fox jumps', 'over the lazy'
+                          - stimulus      (presentation) object 'the quick brown' 'fox jumps', 'over the lazy'
                           - stimulus_id   (presentation) int64 0 1 2}
         """
 
@@ -125,8 +125,8 @@ class ArtificialSubject:
             :meth:`~brainscore_language.artificial_subject.ArtificialSubject.perform_behavioral_task` and/or
             :meth:`~brainscore_language.artificial_subject.ArtificialSubject.perform_neural_recording` respectively.
             The :class:`~brainio.assemblies.DataAssembly` always contains a `presentation` dimension, corresponding to
-            the presentation of text stimuli (including a `context` coordinate for the text,
-            and a `stimulus_id` coordinate that uniquely identifies each context).
+            the presentation of text stimuli (including a `stimulus` coordinate for the text,
+            and a `stimulus_id` coordinate that uniquely identifies each stimulus).
             Values along the `presentation` dimension are ordered in the same way as the input.
             The `behavior` output has no other dimension, while the `neural` output has a `neuroid` dimension
             (including a `neuroid_id` coordinate to uniquely identify each recording unit), and sometimes a

--- a/brainscore_language/benchmarks/futrell2018/test.py
+++ b/brainscore_language/benchmarks/futrell2018/test.py
@@ -15,7 +15,7 @@ class TestBenchmark:
         def digest_text(self, stimuli):
             return {'behavior': BehavioralAssembly(
                 self.reading_times,
-                coords={'context': ('presentation', stimuli), 'stimulus_id': ('presentation', np.arange(len(stimuli)))},
+                coords={'stimulus': ('presentation', stimuli), 'stimulus_id': ('presentation', np.arange(len(stimuli)))},
                 dims=['presentation'])}
 
         def perform_behavioral_task(self, task: ArtificialSubject.Task):

--- a/brainscore_language/benchmarks/wikitext_next_word/test.py
+++ b/brainscore_language/benchmarks/wikitext_next_word/test.py
@@ -11,7 +11,7 @@ class TestBenchmark:
         def digest_text(self, stimuli):
             return {'behavior': BehavioralAssembly(
                 ['the' for passage in stimuli],
-                coords={'context': ('presentation', stimuli), 'stimulus_id': ('presentation', np.arange(len(stimuli)))},
+                coords={'stimulus': ('presentation', stimuli), 'stimulus_id': ('presentation', np.arange(len(stimuli)))},
                 dims=['presentation'])}
 
         def perform_behavioral_task(self, task: ArtificialSubject.Task):

--- a/brainscore_language/model_helpers/embedding.py
+++ b/brainscore_language/model_helpers/embedding.py
@@ -55,7 +55,7 @@ class GensimKeyedVectorsSubject(ArtificialSubject):
             representations = self._encode_sentence(text_part)  # encode every word
             representations = self._average_representations(representations)  # reduce to single representation
             # package
-            stimuli_coords = {'context': ('presentation', [text_part]),
+            stimuli_coords = {'stimulus': ('presentation', [text_part]),
                               'part_number': ('presentation', [part_number])}
             neural_assembly = self.package_representations(representations, stimuli_coords=stimuli_coords)
             output['neural'].append(neural_assembly)

--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -91,7 +91,8 @@ class HuggingfaceSubject(ArtificialSubject):
 
             # format output
             stimuli_coords = {
-                'context': ('presentation', [text_part]),
+                'stimulus': ('presentation', [text_part]),
+                'context': ('presentation', [context]),
                 'part_number': ('presentation', [part_number]),
             }
             if self.behavioral_task:

--- a/brainscore_language/models/glove/test.py
+++ b/brainscore_language/models/glove/test.py
@@ -15,5 +15,5 @@ def test_neural():
                                    recording_type=ArtificialSubject.RecordingType.fMRI)
     representations = model.digest_text(text)['neural']
     assert len(representations['presentation']) == 4
-    np.testing.assert_array_equal(representations['context'], text)
+    np.testing.assert_array_equal(representations['stimulus'], text)
     assert len(representations['neuroid']) == expected_feature_size

--- a/brainscore_language/models/gpt/test.py
+++ b/brainscore_language/models/gpt/test.py
@@ -45,5 +45,5 @@ def test_neural(model_identifier, feature_size):
                                    recording_type=ArtificialSubject.RecordingType.fMRI)
     representations = model.digest_text(text)['neural']
     assert len(representations['presentation']) == 3
-    np.testing.assert_array_equal(representations['context'], text)
+    np.testing.assert_array_equal(representations['stimulus'], text)
     assert len(representations['neuroid']) == feature_size

--- a/tests/test_model_helpers/test_embedding.py
+++ b/tests/test_model_helpers/test_embedding.py
@@ -26,7 +26,7 @@ class TestNeural:
                                        recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(word)['neural']
         assert len(representations['presentation']) == 1
-        assert representations['context'].squeeze() == word
+        assert representations['stimulus'].squeeze() == word
         assert len(representations['neuroid']) == 3
 
     def test_multi_word(self):
@@ -37,7 +37,7 @@ class TestNeural:
                                        recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 1
-        assert representations['context'].squeeze() == text
+        assert representations['stimulus'].squeeze() == text
         assert len(representations['neuroid']) == 3
 
     def test_list_input(self):
@@ -48,7 +48,7 @@ class TestNeural:
                                        recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 4
-        np.testing.assert_array_equal(representations['context'], text)
+        np.testing.assert_array_equal(representations['stimulus'], text)
         assert len(representations['neuroid']) == 3
 
     def test_one_text_two_targets(self):
@@ -63,7 +63,7 @@ class TestNeural:
             recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 1
-        assert representations['context'].squeeze() == text
+        assert representations['stimulus'].squeeze() == text
         assert len(representations['neuroid']) == 3 * 2
         assert set(representations['recording_target'].values) == {
             ArtificialSubject.RecordingTarget.language_system_left_hemisphere,

--- a/tests/test_model_helpers/test_huggingface.py
+++ b/tests/test_model_helpers/test_huggingface.py
@@ -135,7 +135,7 @@ class TestNeural:
                                        recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 3
-        np.testing.assert_array_equal(representations['context'], text)
+        np.testing.assert_array_equal(representations['stimulus'], text)
         assert len(representations['neuroid']) == 768
 
     @pytest.mark.memory_intense
@@ -153,7 +153,7 @@ class TestNeural:
                                        recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 1
-        assert representations['context'].squeeze() == text
+        assert representations['stimulus'].squeeze() == text
         assert len(representations['neuroid']) == 768
         logging.info(f'representation shape is correct: {representations.shape}')
 
@@ -172,7 +172,7 @@ class TestNeural:
             recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 1
-        assert representations['context'].squeeze() == text
+        assert representations['stimulus'].squeeze() == text
         assert len(representations['neuroid']) == 768 * 2
         assert set(representations['region'].values) == {
             ArtificialSubject.RecordingTarget.language_system_left_hemisphere,


### PR DESCRIPTION
`context` in NLP is usually used for the entire history, or all preceding context, not just the current stimulus