### PR TITLE
update plugin name (for display only)

### DIFF
--- a/brainscore_language/plugin_management/run_plugin.sh
+++ b/brainscore_language/plugin_management/run_plugin.sh
@@ -6,7 +6,7 @@ HAS_REQUIREMENTS=$3
 PLUGIN_REQUIREMENTS_PATH=$PLUGIN_PATH/requirements.txt
 PLUGIN_TEST_PATH=$PLUGIN_PATH/test.py
 
-echo $PLUGIN_NAME
+echo "${PLUGIN_NAME/_//}"   
 
 if $HAS_REQUIREMENTS; then
 	eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"


### PR DESCRIPTION
Plugin runner now displays currently running plugin name with `/` instead of `_` between plugin type directory name (`benchmarks`, `metrics`, etc.) and plugin directory name, e.g. `benchmarks_pereira2018` --> `benchmarks/pereira2018`.

(This is for display only; `plugin_name` retains the underscore to share naming with a plugin's `conda` environment, which can't contain `/`.)