### PR TITLE
make `examples.md` symlink to examples README

### DIFF
--- a/docs/source/examples.md
+++ b/docs/source/examples.md
@@ -1,1 +1,12 @@
-../../examples/README.md
+# Notebook examples
+
+[score](https://github.com/brain-score/language/blob/main/examples/score.ipynb): 
+    score an existing model on an existing benchmark.
+
+[score_layers](https://github.com/brain-score/language/blob/main/examples/score_layers.ipynb): 
+    score different layers of a model.
+
+[compare_within_species](https://github.com/brain-score/language/blob/main/examples/compare_within_species.ipynb): 
+    score how similar models are to models, or how similar humans are to humans.
+
+See also the [documentation](https://brain-score-language.readthedocs.io/).


### PR DESCRIPTION
Make the examples README.md actually show up in the docs (like https://github.com/brain-score/brain-score/tree/master/docs/source).

`ln -s ../../examples/README.md examples.md`