### PR TITLE
Fix pre-tokenized content for multipart context inputs in HuggingfaceSubject

### DIFF
--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 from collections import OrderedDict
+import re
 from typing import Union, List, Tuple, Dict, Callable
 
 import numpy as np
@@ -80,8 +81,8 @@ class HuggingfaceSubject(ArtificialSubject):
 
         text_iterator = tqdm(text, desc='digest text') if len(text) > 1 else text  # show progress bar if multiple parts
         for part_number, text_part in enumerate(text_iterator):
-            # tokenize
-            context = ' '.join(text[:part_number + 1])  # build up context over items in the text
+            # prepare string representation of context
+            context = self._prepare_context(text[:part_number + 1])
             context_tokens, number_of_tokens = self._tokenize(context, number_of_tokens)
 
             # prepare recording hooks
@@ -118,6 +119,18 @@ class HuggingfaceSubject(ArtificialSubject):
         output['neural'] = xr.concat(output['neural'], dim='presentation').sortby('part_number') \
             if output['neural'] else None
         return output
+
+    def _prepare_context(self, context_parts):
+        """
+        Prepare a single string representation of a (possibly partial) input context
+        for the model.
+        """
+        context = ' '.join(context_parts)
+
+        # Remove erroneous spaces before punctuation.
+        context = re.sub(r'\s+([.,!?;:])', r'\1', context)
+
+        return context
 
     def _tokenize(self, context, num_previous_context_tokens):
         """

--- a/tests/test_model_helpers/test_huggingface.py
+++ b/tests/test_model_helpers/test_huggingface.py
@@ -47,6 +47,14 @@ class TestNextWord:
         next_words = model.digest_text(text)['behavior']
         np.testing.assert_array_equal(next_words, expected_next_words)
 
+    def test_context_cleaning(self):
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
+        # model.start_behavioral_task(task=ArtificialSubject.Task.next_word)
+        # next_words = model.digest_text('the quick, and sneaky, brown fox')['behavior']
+        # assert next_words == 'jumps'
+        prepared_context = model._prepare_context(["the quick", ", and sneaky", "brown fox"])
+        assert prepared_context == "the quick, and sneaky brown fox"
+
     def test_over_max_length_input(self):
         # max_input_length of distilgpt2 is 1024 tokens. Prompt it with text longer than this length, the model should
         # handle this case gracefully and not fail (e.g. truncate input)


### PR DESCRIPTION
Currently the `HuggingfaceSubject` implementation joins the input string parts by a space. This produces unpleasant strings when a part has punctuation at its left edge. For example, the list of parts `["the quick", ", and sneaky brown fox"]` yields `"the quick , and sneaky brown fox"` -- note the space before the comma.

This hacky PR simply retroactively removes the pre-punctuation spaces.

The bug addressed by this PR currently would affect any computation using the multipart functionality (reading times and SyntaxGym). cf #91 