### PR TITLE
debugging infinite hang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ install:
   # install singularity for container models
   - conda install -yc conda-forge singularity
 script:
-  - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
-  - python brainscore_language/plugin_management/test_plugins.py
+#  - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
+#  - python brainscore_language/plugin_management/test_plugins.py
+  - python brainscore_language/benchmarks/pereira2018/test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     fi
   - python -m pip install -e ".[test]"
   - pip install "brainio@git+https://github.com/brain-score/brainio.git@c60ed99"  # FIXME
-  - pip uninstall dask  # dask bad FIXME
+  - pip uninstall -y dask  # dask bad FIXME
   # install conda for plugin runner
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
     fi
   - python -m pip install -e ".[test]"
   - pip install "brainio@git+https://github.com/brain-score/brainio.git@c60ed99"  # FIXME
+  - pip uninstall dask  # dask bad FIXME
   # install conda for plugin runner
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ install:
   # install singularity for container models
   - conda install -yc conda-forge singularity
 script:
-#  - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
-#  - python brainscore_language/plugin_management/test_plugins.py
-  - python brainscore_language/benchmarks/pereira2018/test.py
+#    - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
+    - python brainscore_language/plugin_management/test_plugins.py
+#  - python brainscore_language/benchmarks/pereira2018/test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
 python:
-  - "3.7"
+#  - "3.7"
   - "3.8"
-  - "3.9"
+#  - "3.9"
 install:
   # fix setuptools for python 3.7, error in other versions https://github.com/pypa/setuptools/issues/3293
   - if [[ $TRAVIS_PYTHON_VERSION == 3.7* ]]; then
     pip install "setuptools==60.5.0";
     fi
   - python -m pip install -e ".[test]"
+  - pip install "brainio@git+https://github.com/brain-score/brainio.git@c60ed99"  # FIXME
   # install conda for plugin runner
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/brainscore_language/benchmarks/pereira2018/test.py
+++ b/brainscore_language/benchmarks/pereira2018/test.py
@@ -1,3 +1,5 @@
+import time
+
 import copy
 import numpy as np
 import pytest
@@ -6,6 +8,16 @@ from pytest import approx
 
 from brainio.assemblies import NeuroidAssembly
 from brainscore_language import ArtificialSubject, load_benchmark
+
+
+def test_dummy():
+    print("I'm alive")
+    assert True
+
+
+def test_sometimeout():
+    time.sleep(10)
+    print("Still here")
 
 
 class TestBenchmark:

--- a/brainscore_language/benchmarks/pereira2018/test.py
+++ b/brainscore_language/benchmarks/pereira2018/test.py
@@ -101,4 +101,4 @@ if __name__ == '__main__':
     test_benchmark.test_exact(243)
 
     print(">> test_ceiling")
-    test_benchmark.test_ceiling(243)
+    test_benchmark.test_ceiling(243, .35378928)

--- a/brainscore_language/benchmarks/pereira2018/test.py
+++ b/brainscore_language/benchmarks/pereira2018/test.py
@@ -83,3 +83,22 @@ class TestBenchmark:
         assert ceiling.raw.median() == ceiling
         assert hasattr(ceiling.raw, 'raw')
         assert set(ceiling.raw.raw.dims) == {'sub_subject', 'num_subjects', 'split', 'neuroid'}
+
+
+if __name__ == '__main__':
+    print(">> test_dummy")
+    test_dummy()
+
+    print(">> test_sometimeout")
+    test_sometimeout()
+
+    test_benchmark = TestBenchmark()
+
+    print(">> test_dummy_bad")
+    test_benchmark.test_dummy_bad(243, approx(0.0017534 / .35378928, abs=0.001))
+
+    print(">> test_exact")
+    test_benchmark.test_exact(243)
+
+    print(">> test_ceiling")
+    test_benchmark.test_ceiling(243)

--- a/brainscore_language/plugin_management/test_plugin.sh
+++ b/brainscore_language/plugin_management/test_plugin.sh
@@ -10,13 +10,13 @@ SINGLE_TEST=$4
 echo "${PLUGIN_NAME/_//}"
 
 eval "$(command conda 'shell.bash' 'hook' 2>/dev/null)"
-output=$(conda create -n $PLUGIN_NAME python=3.8 -y 2>&1) || echo $output
+conda create -n $PLUGIN_NAME python=3.8 -y
 conda activate $PLUGIN_NAME
 if $HAS_REQUIREMENTS; then
-  output=$(pip install -r $PLUGIN_REQUIREMENTS_PATH 2>&1) || echo $output
+  pip install -r $PLUGIN_REQUIREMENTS_PATH
 fi
 
-output=$(python -m pip install -e ".[test]" 2>&1) || echo $output
+python -m pip install -e ".[test]"
 
 if [ "$SINGLE_TEST" != False ]; then
   echo "Running ${SINGLE_TEST}"

--- a/brainscore_language/plugin_management/test_plugin.sh
+++ b/brainscore_language/plugin_management/test_plugin.sh
@@ -18,6 +18,8 @@ fi
 
 python -m pip install -e ".[test]"
 
+pip uninstall -y dask
+
 if [ "$SINGLE_TEST" != False ]; then
   echo "Running ${SINGLE_TEST}"
   pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" "-s" $PLUGIN_TEST_PATH "-k" $SINGLE_TEST "--log-cli-level=INFO"

--- a/brainscore_language/plugin_management/test_plugin.sh
+++ b/brainscore_language/plugin_management/test_plugin.sh
@@ -20,9 +20,9 @@ python -m pip install -e ".[test]"
 
 if [ "$SINGLE_TEST" != False ]; then
   echo "Running ${SINGLE_TEST}"
-  pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" $PLUGIN_TEST_PATH "-k" $SINGLE_TEST "--log-cli-level=INFO"
+  pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" "-s" $PLUGIN_TEST_PATH "-k" $SINGLE_TEST "--log-cli-level=INFO"
 else
-  pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" $PLUGIN_TEST_PATH
+  pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" "-s" $PLUGIN_TEST_PATH
 fi
 
 exit $?

--- a/brainscore_language/plugin_management/test_plugin.sh
+++ b/brainscore_language/plugin_management/test_plugin.sh
@@ -22,7 +22,7 @@ if [ "$SINGLE_TEST" != False ]; then
   echo "Running ${SINGLE_TEST}"
   pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" $PLUGIN_TEST_PATH "-k" $SINGLE_TEST "--log-cli-level=INFO"
 else
-  pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" $PLUGIN_TEST_PATH
+  pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow" "-vv" $PLUGIN_TEST_PATH
 fi
 
 exit $?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ requires-python = ">=3.7"
 dependencies = [
     "tqdm",
     "numpy>=1.21",
-    "brainscore_core@git+https://github.com/brain-score/core.git",
-    "brainio@git+https://github.com/brain-score/brainio.git",
+    "brainscore_core@git+https://github.com/brain-score/core.git@main",
+    "brainio@git+https://github.com/brain-score/brainio.git@main",
     "fire",
     # model_helpers dependencies
     "torch>=1.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "tqdm",
     "numpy>=1.21",
     "brainscore_core@git+https://github.com/brain-score/core.git@main",
-    "brainio@git+https://github.com/brain-score/brainio.git@main",
+    "brainio@git+https://github.com/brain-score/brainio.git@c60ed99",
     "fire",
     # model_helpers dependencies
     "torch>=1.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "torch>=1.9.1",
     "transformers>=4.11.3",
     # FIXME
+    "scikit-learn==1.1.2",
     "boto3==1.25.0",
     "botocore==1.28.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ requires-python = ">=3.7"
 dependencies = [
     "tqdm",
     "numpy>=1.21",
-    "brainscore_core@git+https://github.com/brain-score/core.git@main",
-    "brainio@git+https://github.com/brain-score/brainio.git@c60ed99",
+    "brainscore_core@git+https://github.com/brain-score/core.git",
+    "brainio@git+https://github.com/brain-score/brainio.git",
     "fire",
     # model_helpers dependencies
     "torch>=1.9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "scikit-learn==1.1.2",
     "boto3==1.25.0",
     "botocore==1.28.0",
+    "pandas==1.3.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     # model_helpers dependencies
     "torch>=1.9.1",
     "transformers>=4.11.3",
+    # FIXME
+    "boto3==1.25.0",
+    "botocore==1.28.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- [x] ~try pinning boto versions~
- [x] ~is dummy output reached in benchmarks/pereira2018/test.py? --> yes~
- [x] ~new evidence: there is a diff between `main` and the last successful build in branch `kvf/scoring`: https://github.com/brain-score/language/compare/main...kvf/scoring == this is incorrect, github is just unable to compare commit histories. The files are identical.~
- [x] ~does it run if we invoke only the plugin tests? --> no, hangs~
- [x] ~does the `pytest` output for the pereira2018 benchmark plugin tell us anything? --> seems like it gets stuck in cross-validation~
- [x] ~maybe there's some issue with xarray/pandas versions?~
- [x] ~pin sklearn --> same problem with 1.1.2 (August release; although this only exists for python >=3.8~
- [x] ~pin pandas --> no effect~
- [x] ~does it run if we call the `test.py` file from travis directly? --> it runs in python 3.7, but not 3.8. Version diffs (pipenv had a release yesterday)~
- [x] what if we uninstall dask in travis setup and the plugin runner?

The culprit is dask, introduced in https://github.com/brain-score/brainio/pull/32. Specifically, brainio introduced a dependency `dask;python_version>'3.7'`, i.e. dask is installed for python versions greater than 3.7.

`test_integration` for python>3.7 hangs right away because dask is already installed. For python 3.7 it is not yet, so test_integration works, but when it gets to plugin installation, it uses an environment with a newer python where dask is installed again and leads to tests hanging.