### PR TITLE
Change default model embeddings for GPT

### DIFF
--- a/brainscore_language/models/gpt/__init__.py
+++ b/brainscore_language/models/gpt/__init__.py
@@ -6,7 +6,7 @@ from brainscore_language.model_helpers.huggingface import HuggingfaceSubject
 # https://github.com/mschrimpf/neural-nlp/blob/master/precomputed-scores.csv
 
 model_registry['distilgpt2'] = lambda: HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={
-    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.5.mlp.dropout'})
+    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.5'})
 
 model_registry['gpt2-xl'] = lambda: HuggingfaceSubject(model_id='gpt2-xl', region_layer_mapping={
-    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.43.mlp.dropout'})
+    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.43'})


### PR DESCRIPTION
Change default model embeddings for GPT to the output of the transformer block (i.e., output_hidden_states=True) instead of the MLP dropout layer.