### PR TITLE
remove `test_plugins` from `__main__`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
   - conda install -yc conda-forge singularity
 script:
   - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
-  - python brainscore_language test_plugins
+  - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"

--- a/brainscore_language/__main__.py
+++ b/brainscore_language/__main__.py
@@ -2,18 +2,12 @@ from pathlib import Path
 
 import fire
 
-from brainscore_core.plugin_management.test_plugins import run_args as _core_test_plugins
 from brainscore_language import score as _score_function
 
 
 def score(model_identifier: str, benchmark_identifier: str):
     result = _score_function(model_identifier, benchmark_identifier)
     print(result)  # print instead of return because fire has issues with xarray objects
-
-
-def test_plugins(*args, **kwargs):
-    root_directory = Path(__file__).parent
-    _core_test_plugins(*args, root_directory=root_directory, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Takes plugin testing out of `__main__` 

Has the benefit of keeping `core`’s test dependencies optional rather than required.