### PR TITLE
Adding syntaxgym-2020 to the benchmark registry

### DIFF
--- a/brainscore_language/benchmarks/syntaxgym/__init__.py
+++ b/brainscore_language/benchmarks/syntaxgym/__init__.py
@@ -6,6 +6,7 @@ from .benchmark import SyntaxGymSingleTSE, SyntaxGym2020
 with open(Path(__file__).parent / 'test_suites.json') as json_file:
     test_suite_dict = json.load(json_file)
 
+benchmark_registry['syntaxgym-2020'] = lambda: SyntaxGym2020()
 benchmark_registry['center_embed'] = lambda: SyntaxGymSingleTSE(test_suite_dict['center_embed'])
 benchmark_registry['center_embed_mod'] = lambda: SyntaxGymSingleTSE(test_suite_dict['center_embed_mod'])
 benchmark_registry['cleft'] = lambda: SyntaxGymSingleTSE(test_suite_dict['cleft'])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,7 @@ from brainscore_language import score
         ("distilgpt2", "Pereira2018.243sentences-linear", approx(0.73772422, abs=0.0005)),
         ("glove-840b", "Pereira2018.384sentences-linear", approx(0.18385368, abs=0.0005)),
         ("gpt2-xl", "Futrell2018-pearsonr", approx(0.31825621, abs=0.0005)),
+        ('distilgpt2', 'syntaxgym-2020', approx(0.51398774, abs=.0005)),
         ('distilgpt2', 'center_embed', approx(0.96428571, abs=.0005)),
         ('distilgpt2', 'center_embed_mod', approx(0.92857143, abs=.0005)),
         ('distilgpt2', 'cleft', approx(1.0, abs=.0005)),


### PR DESCRIPTION
Put syntaxgym-2020 back into the benchmark registry.  It currently outputs the average scores of the 31 individual SG benchmarks.