### PR TITLE
fix version to <= last release before 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
-    "pytest-check",
+    "pytest-check<=1.3.0",
     "gensim",
     "joblib",
 ]


### PR DESCRIPTION
To permit Travis to  register `pytest` errors but continue testing all plugins if any plugin tests fail, we use `pytest-check`, a `pytest` plugin that allows multiple failures per test. When all tests are skipped (for instance, for memory intensive models such as GPT), expected behavior is that the process exits with a return code of 1. The `pytest-check` 2.0 release on 1/8 fails to gracefully handle this exit, so this PR fixes `pytest-check` at the last release prior to 2.0 (1.3.0) or earlier.

