### PR TITLE
Adding Benchmark Cards

### DIFF
--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -5,6 +5,7 @@ to a wide variety of researchers.  See the [SyntaxGym Website](https://syntaxgym
 
 ## YAML section for Benchmark Card
 ---
+```yaml
 benchmark details:
   name: SyntaxGym (Center Embedding)
   developer: MIT Computational Psycholinguistics Lab
@@ -69,5 +70,4 @@ example_usage:
     benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
     score = benchmark(model)
     ```
---- 
 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -35,7 +35,7 @@ benchmark details:
     year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-demos.10", pages = "70--76"}
 
 experiment:
-  task: Currently either "next_word" or "reading_times"
+  task: "reading_times"
   recording: NA
   experiment_card: NA
   bidirectionality: NA

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -43,7 +43,7 @@ experiment:
 
 data:
   accessibility: public
-  measurement_type: behavioral
+  measurement_type: NA
   granularity: NA
   method: NA
   references: Wilcox E. Levy R. & Futrell R. (2019). 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -27,7 +27,7 @@ benchmark details:
 
 experiment:
   task: Currently either "next_word" or "reading_times"
-  recording: fMRI
+  recording: NA
   experiment_card: NA
   bidirectionality: NA
   contextualization: NA

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -59,22 +59,20 @@ ethical_considerations: NA
 recommendations: NA
 
 example_usage:
-  example: see test_integration.py for example usage
-  note: |
-    To use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
+  example: see test_integration.py for example usage |
     ```
+    from brainscore_language import load_model, load_benchmark
+    model = load_model("distilgpt2")
+    benchmark = load_benchmark("center_embed")
+    score=benchmark(model)
+    
+    or
+    
+    #  to use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
     from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
     from brainscore_language import load_model
     model = load_model("distilgpt2")
     benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
     score = benchmark(model)
-    
-    or
-    
-    from brainscore_language import load_model, load_benchmark
-    model = load_model("distilgpt2")
-    benchmark = load_benchmark("center_embed")
-    score=benchmark(model)
-    print(score)
     ```
 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -1,0 +1,74 @@
+SyntaxGym is a unified platform for targeted syntactic evaluation of language models. It supports all steps
+of the evaluation process, from designing test suites to visualizing final results. The goal of SyntaxGym 
+is to make psycholinguistic assessment of language models more standardized, reproducible, and accessible 
+to a wide variety of researchers.  See the [SyntaxGym Website](https://syntaxgym.org/) for more details.
+
+## YAML section for Benchmark Card
+---
+benchmark details:
+  developer: MIT Computational Psycholinguistics Lab
+  date: 2020
+  questions: mitcpllab@gmail.com
+  version: 1.0
+  type: behavioral
+  license: MIT
+  citations: |
+  @inproceedings{hu-etal-2020-systematic,
+  title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
+  author = "Hu, Jennifer and Gauthier, Jon and Qian, Peng and Wilcox, Ethan and Levy, Roger",
+  booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics", 
+  year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-main.158", pages = "1725--1744"}
+  @inproceedings{gauthier-etal-2020-syntaxgym, 
+  title = "{S}yntax{G}ym: An Online Platform for Targeted Evaluation of Language Models", 
+  author = "Gauthier, Jon and Hu, Jennifer and Wilcox, Ethan and Qian, Peng and Levy, Roger",
+  booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
+  year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-demos.10", pages = "70--76"}
+
+experiment:
+  task: Currently either "next_word" or "reading_times"
+  recording: fMRI
+  modelcard: NA
+  bidirectionality: NA
+  contextualization: NA
+
+data:
+  accessibility: public
+  modality: behavioral
+  granularity: NA
+  method: NA
+  references: |
+  Wilcox E. Levy R. & Futrell R. (2019). Hierarchical representation in neural language models: Suppression and 
+  recovery of expectations.
+
+  location: in the benchmark, as a json
+  description: |
+  Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark 
+  feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for 
+  some language models. To succeed in generating expectations about how sentences will continue in the context of 
+  multiple center embedding, a model must maintain a representation not only of what words appear in the preceding 
+  context but also of the order of those words, and must predict that upcoming words occur in the appropriate order. 
+  In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
+
+metric:
+  mapping: N/A 
+  metric: accuracy
+  crossvalstrat: N/A
+  crossvalsplitcoord: N/A
+
+ethical_considerations: N/A
+
+recommendations: N/A
+
+example_usage:
+  example: see test_integration.py for example usage
+  note: |
+  To use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
+  ```
+  from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
+  from brainscore_language import load_model
+  model = load_model("distilgpt2")
+  benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
+  score = benchmark(model)
+  ```
+ --- 
+

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -9,10 +9,18 @@ benchmark details:
   name: SyntaxGym (Center Embedding)
   developer: MIT Computational Psycholinguistics Lab
   date: 2020
-  questions: mitcpllab@gmail.com
   version: 1.0
   type: behavioral
+  description: |
+    Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark 
+    feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for 
+    some language models. To succeed in generating expectations about how sentences will continue in the context of 
+    multiple center embedding, a model must maintain a representation not only of what words appear in the preceding 
+    context but also of the order of those words, and must predict that upcoming words occur in the appropriate order. 
+    In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
+
   license: MIT
+  questions: mitcpllab@gmail.com
   citations: |
     @inproceedings{hu-etal-2020-systematic,
     title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
@@ -39,14 +47,6 @@ data:
   method: NA
   references: Wilcox E. Levy R. & Futrell R. (2019). 
   location: in the benchmark as a json
-  
-  description: |
-    Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark 
-    feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for 
-    some language models. To succeed in generating expectations about how sentences will continue in the context of 
-    multiple center embedding, a model must maintain a representation not only of what words appear in the preceding 
-    context but also of the order of those words, and must predict that upcoming words occur in the appropriate order. 
-    In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
 
 metric:
   mapping: N/A 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -69,7 +69,7 @@ example_usage:
     
     or
     
-    #  to use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
+    # to use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
     from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
     from brainscore_language import load_model
     model = load_model("distilgpt2")

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -61,6 +61,7 @@ recommendations: NA
 example_usage:
   example: see test_integration.py for example usage |
     ```
+    # to use a benchmark already in the benchmark registry
     from brainscore_language import load_model, load_benchmark
     model = load_model("distilgpt2")
     benchmark = load_benchmark("center_embed")

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -68,5 +68,13 @@ example_usage:
     model = load_model("distilgpt2")
     benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
     score = benchmark(model)
+    
+    or
+    
+    from brainscore_language import load_model, load_benchmark
+    model = load_model("distilgpt2")
+    benchmark = load_benchmark("cleft")
+    score=benchmark(model)
+    print(score)
     ```
 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -6,6 +6,7 @@ to a wide variety of researchers.  See the [SyntaxGym Website](https://syntaxgym
 ## YAML section for Benchmark Card
 ---
 benchmark details:
+  name: SyntaxGym (Center Embedding)
   developer: MIT Computational Psycholinguistics Lab
   date: 2020
   questions: mitcpllab@gmail.com
@@ -33,7 +34,7 @@ experiment:
 
 data:
   accessibility: public
-  modality: behavioral
+  measurement_type: behavioral
   granularity: NA
   method: NA
   references: Wilcox E. Levy R. & Futrell R. (2019). 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -73,7 +73,7 @@ example_usage:
     
     from brainscore_language import load_model, load_benchmark
     model = load_model("distilgpt2")
-    benchmark = load_benchmark("cleft")
+    benchmark = load_benchmark("center_embed")
     score=benchmark(model)
     print(score)
     ```

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -13,16 +13,16 @@ benchmark details:
   type: behavioral
   license: MIT
   citations: |
-  @inproceedings{hu-etal-2020-systematic,
-  title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
-  author = "Hu, Jennifer and Gauthier, Jon and Qian, Peng and Wilcox, Ethan and Levy, Roger",
-  booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics", 
-  year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-main.158", pages = "1725--1744"}
-  @inproceedings{gauthier-etal-2020-syntaxgym, 
-  title = "{S}yntax{G}ym: An Online Platform for Targeted Evaluation of Language Models", 
-  author = "Gauthier, Jon and Hu, Jennifer and Wilcox, Ethan and Qian, Peng and Levy, Roger",
-  booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
-  year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-demos.10", pages = "70--76"}
+    @inproceedings{hu-etal-2020-systematic,
+    title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
+    author = "Hu, Jennifer and Gauthier, Jon and Qian, Peng and Wilcox, Ethan and Levy, Roger",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics", 
+    year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-main.158", pages = "1725--1744"}
+    @inproceedings{gauthier-etal-2020-syntaxgym, 
+    title = "{S}yntax{G}ym: An Online Platform for Targeted Evaluation of Language Models", 
+    author = "Gauthier, Jon and Hu, Jennifer and Wilcox, Ethan and Qian, Peng and Levy, Roger",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
+    year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-demos.10", pages = "70--76"}
 
 experiment:
   task: Currently either "next_word" or "reading_times"
@@ -36,18 +36,16 @@ data:
   modality: behavioral
   granularity: NA
   method: NA
-  references: |
-  Wilcox E. Levy R. & Futrell R. (2019). Hierarchical representation in neural language models: Suppression and 
-  recovery of expectations.
-
-  location: in the benchmark, as a json
+  references: Wilcox E. Levy R. & Futrell R. (2019). 
+  location: in the benchmark as a json
+  
   description: |
-  Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark 
-  feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for 
-  some language models. To succeed in generating expectations about how sentences will continue in the context of 
-  multiple center embedding, a model must maintain a representation not only of what words appear in the preceding 
-  context but also of the order of those words, and must predict that upcoming words occur in the appropriate order. 
-  In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
+    Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark 
+    feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for 
+    some language models. To succeed in generating expectations about how sentences will continue in the context of 
+    multiple center embedding, a model must maintain a representation not only of what words appear in the preceding 
+    context but also of the order of those words, and must predict that upcoming words occur in the appropriate order. 
+    In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
 
 metric:
   mapping: N/A 
@@ -62,13 +60,13 @@ recommendations: N/A
 example_usage:
   example: see test_integration.py for example usage
   note: |
-  To use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
-  ```
-  from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
-  from brainscore_language import load_model
-  model = load_model("distilgpt2")
-  benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
-  score = benchmark(model)
-  ```
- --- 
+    To use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html) 
+    ```
+    from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
+    from brainscore_language import load_model
+    model = load_model("distilgpt2")
+    benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
+    score = benchmark(model)
+    ```
+--- 
 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -22,7 +22,7 @@ benchmark details:
 
   license: MIT
   questions: mitcpllab@gmail.com
-  citations: |
+  references: |
     @inproceedings{hu-etal-2020-systematic,
     title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
     author = "Hu, Jennifer and Gauthier, Jon and Qian, Peng and Wilcox, Ethan and Levy, Roger",

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -50,14 +50,14 @@ data:
   location: in the benchmark as a json
 
 metric:
-  mapping: N/A 
+  mapping: NA 
   metric: accuracy
-  crossvalstrat: N/A
-  crossvalsplitcoord: N/A
+  crossvalstrat: NA
+  crossvalsplitcoord: NA
 
-ethical_considerations: N/A
+ethical_considerations: NA
 
-recommendations: N/A
+recommendations: NA
 
 example_usage:
   example: see test_integration.py for example usage

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -27,7 +27,7 @@ benchmark details:
 experiment:
   task: Currently either "next_word" or "reading_times"
   recording: fMRI
-  modelcard: NA
+  experiment_card: NA
   bidirectionality: NA
   contextualization: NA
 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -44,7 +44,7 @@ experiment:
 data:
   accessibility: public
   measurement_type: NA
-  granularity: NA
+  granularity: per sentence surprisal evaluation
   method: NA
   references: Wilcox E. Levy R. & Futrell R. (2019). 
   location: in the benchmark as a json
@@ -52,8 +52,7 @@ data:
 metric:
   mapping: NA 
   metric: accuracy
-  crossvalstrat: NA
-  crossvalsplitcoord: NA
+  error_estimation: cross validation over sentences, stratified by passage
 
 ethical_considerations: NA
 

--- a/brainscore_language/benchmarks/syntaxgym/README.md
+++ b/brainscore_language/benchmarks/syntaxgym/README.md
@@ -3,7 +3,7 @@ of the evaluation process, from designing test suites to visualizing final resul
 is to make psycholinguistic assessment of language models more standardized, reproducible, and accessible 
 to a wide variety of researchers.  See the [SyntaxGym Website](https://syntaxgym.org/) for more details.
 
-## YAML section for Benchmark Card
+## Benchmark: SyntaxGym (Center Embedding)
 ---
 ```yaml
 benchmark details:

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -369,7 +369,7 @@ following format as a guideline:
 
       data:
         accessibility: <public or private>
-        measurement_type: <behavioral/neural and modality, e.g. neural; fMRI
+        type: <behavioral/neural and modality, e.g. neural; fMRI>
         granularity: <neural data granularity, e.g. whether there is any aggregation such as fROIs>
         method: <how was the data obtained e.g. # of participants, demographics, # of unique items, reps per item, etc.>
         data_card: <reference any existing data cards>

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -343,7 +343,9 @@ Benchmark Card Creation
 
 Please include a :code:`README.md` file along with your benchmark to aid users with understanding and implementation.
 As part of your README.md file, please include a YAML "Benchmark Card" section, detailing your benchmark, and using the
-following format as a guideline:
+following format as a guideline. (NOTE: For cases where multiple benchmarks are submitted in a single plugin; a single
+YAML could be appropriate for two very similar benchmarks, and separate YAMLs could be more fitting for dissimilar
+benchmarks. This is left as a decision for the creator).
 
 .. code-block:: python
 

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -350,10 +350,11 @@ As part of your README.md file, please include a YAML section using the followin
         name: <name of the benchmark>
         developer: <developing individual or organization>
         date: <date of benchmark creation>
-        questions: <where to send questions>
         version: <version number>
         type: <behavioral or neural>
+        description: <a short summary description>
         license: <license details>
+        questions: <where to send questions>
         citations: <citation information if relevant>
 
       experiment:
@@ -368,6 +369,7 @@ As part of your README.md file, please include a YAML section using the followin
         measurement_type: <behavioral/neural and modality, e.g. neural; fMRI
         granularity: <neural data granularity>
         method: <how was the data obtained>
+        data_card: <reference any existing data cards>
         references: <abbreviated Bibtex>
 
       metric:

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -361,6 +361,7 @@ As part of your README.md file, please include a YAML section using the followin
         recording: <ArtificialSubject Recording type>
         experiment_card: <reference existing experiment cards>
         bidirectionality: <unidirectional/bidirectional>
+        contextualization: <if contextualized, what preceding context was used>
 
       data:
         accessibility: <public or private>

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -347,6 +347,7 @@ As part of your README.md file, please include a YAML section using the followin
 .. code-block:: python
 
       benchmark_details:
+        name: <name of the benchmark>
         developer: <developing individual or organization>
         date: <date of benchmark creation>
         questions: <where to send questions>
@@ -363,9 +364,9 @@ As part of your README.md file, please include a YAML section using the followin
 
       data:
         accessibility: <public or private>
-        modality: <behavioral/neural and modality, e.g. neural; fMRI
+        measurement_type: <behavioral/neural and modality, e.g. neural; fMRI
         granularity: <neural data granularity>
-        method: <how was the data obtainede?>
+        method: <how was the data obtained>
         references: <abbreviated Bibtex>
 
       metric:
@@ -374,7 +375,7 @@ As part of your README.md file, please include a YAML section using the followin
         crossvalstrat: <cross validation stratification, e.g. passage>
         crossvalsplitcoord: <cross validation split coordinate <e.g. sentence>
 
-      ethical_considerations: <any relevant ethical consideration>
+      ethical_considerations: <any relevant ethical considerations>
 
       recommendations: <any relevant caveats and recommendations>
 

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -344,7 +344,8 @@ Benchmark Card Creation
 Please include a :code:`README.md` file along with your benchmark to aid users with understanding and implementation.
 As part of your README.md file, please include a YAML section using the following format as a guideline:
 
-.. code-block:: yaml
+.. code-block:: python
+
       benchmark_details:
         developer: <developing individual or organization>
         date: <date of benchmark creation>

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -359,7 +359,7 @@ As part of your README.md file, please include a YAML section using the followin
       experiment:
         task: <list of ArtificialSubject task values>
         recording: <ArtificialSubject Recording type>
-        experiment_card: <reference existing experiment cards>
+        experiment_card: <reference any existing experiment cards>
         bidirectionality: <unidirectional/bidirectional>
         contextualization: <if contextualized, what preceding context was used>
 
@@ -373,6 +373,7 @@ As part of your README.md file, please include a YAML section using the followin
       metric:
         mapping: <e.g., RidgeCV, LinReg, RSA>
         metric: <e.g. PearsonR, accuracy>
+        metric_card: <reference any existing metric cards>
         crossvalstrat: <cross validation stratification, e.g. passage>
         crossvalsplitcoord: <cross validation split coordinate <e.g. sentence>
 
@@ -380,7 +381,7 @@ As part of your README.md file, please include a YAML section using the followin
 
       recommendations: <any relevant caveats and recommendations>
 
-      example_usage: <one example should be in test_integration.py>
+      example_usage: <one example should be in test_integration.py, others can be included>
 
 4. Submit to Brain-Score
 ========================

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -376,8 +376,7 @@ As part of your README.md file, please include a YAML section using the followin
         mapping: <e.g., RidgeCV, LinReg, RSA>
         metric: <e.g. PearsonR, accuracy>
         metric_card: <reference any existing metric cards>
-        crossvalstrat: <cross validation stratification, e.g. passage>
-        crossvalsplitcoord: <cross validation split coordinate <e.g. sentence>
+        error_estimation: <methods used for estimating errors>
 
       ethical_considerations: <any relevant ethical considerations>
 

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -363,7 +363,8 @@ following format as a guideline:
         task: <list of ArtificialSubject task value(s) if any>
         recording: <ArtificialSubject Recording type(s) if any>
         experiment_card: <reference any existing experiment cards>
-        bidirectionality: <(if relevant) unidirectional/bidirectional: whether bidirectionality was used to obtain e.g., internal recordings of the model>
+        bidirectionality: <(if relevant) unidirectional/bidirectional: whether bidirectionality was used to obtain e.g.,
+        internal recordings of the model>
         contextualization: <if contextualized, what preceding context was used>
 
       data:

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -352,7 +352,8 @@ following format as a guideline:
         developer: <developing individual or group>
         date: <date of benchmark creation>
         version: <version number>
-        type: <behavioral (tests against behavioral data), neural (tests against neural data), or engineering (others, typically test on ground-truth)>
+        type: <behavioral (tests against behavioral data), neural (tests against neural data), or engineering (others,
+        typically test on ground-truth)>
         description: <a short summary description>
         license: <license details>
         questions: <where to send questions>

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -356,7 +356,7 @@ following format as a guideline:
         description: <a short summary description>
         license: <license details>
         questions: <where to send questions>
-        references: <citation information if relevant>
+        references: <citation/reference information if relevant>
 
       experiment:
         task: <list of ArtificialSubject task value(s) if any>

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -362,10 +362,8 @@ following format as a guideline:
       experiment:
         task: <list of ArtificialSubject task value(s) if any>
         recording: <ArtificialSubject Recording type(s) if any>
-        experiment_card: <reference any existing experiment cards>
         bidirectionality: <(if relevant) unidirectional/bidirectional: whether bidirectionality was used to obtain e.g.,
         internal recordings of the model>
-        contextualization: <if contextualized, what preceding context was used>
 
       data:
         accessibility: <public or private>

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -381,42 +381,6 @@ As part of your README.md file, please include a YAML section using the followin
       example_usage: <one example should be in test_integration.py>
     ---
 
-For instance, the following is an excerpt from the
-`Futrell2018 tests <https://github.com/brain-score/language/blob/85afdae5294d0613fb51c33333aa76c52fc0849e/brainscore_language/benchmarks/futrell2018/test.py>`_:
-
-.. code-block:: python
-
-    from brainscore_language import ArtificialSubject, load_benchmark
-
-    class DummyModel(ArtificialSubject):
-        def __init__(self, reading_times):
-            self.reading_times = reading_times
-
-        def digest_text(self, stimuli):
-            return {'behavior': BehavioralAssembly(self.reading_times, coords={
-                                        'context': ('presentation', stimuli),
-                                        'stimulus_id': ('presentation', np.arange(len(stimuli)))},
-                                    dims=['presentation'])}
-
-        def start_behavioral_task(self, task: ArtificialSubject.Task):
-            if task != ArtificialSubject.Task.reading_times:
-                raise NotImplementedError()
-
-    def test_dummy_bad():
-        benchmark = load_benchmark('Futrell2018-pearsonr')
-        reading_times = RandomState(0).random(10256)
-        dummy_model = DummyModel(reading_times=reading_times)
-        score = benchmark(dummy_model)
-        assert score == approx(0.0098731 / .858, abs=0.001)
-
-    def test_ceiling():
-        benchmark = load_benchmark('Futrell2018-pearsonr')
-        ceiling = benchmark.ceiling
-        assert ceiling == approx(.858, abs=.0005)
-        assert ceiling.raw.median('split') == ceiling
-        assert ceiling.uncorrected_consistencies.median('split') < ceiling
-
-
 4. Submit to Brain-Score
 ========================
 

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -342,39 +342,40 @@ Benchmark Card Creation
 -----------------------
 
 Please include a :code:`README.md` file along with your benchmark to aid users with understanding and implementation.
-As part of your README.md file, please include a YAML section using the following format as a guideline:
+As part of your README.md file, please include a YAML "Benchmark Card" section, detailing your benchmark, and using the
+following format as a guideline:
 
 .. code-block:: python
 
       benchmark_details:
         name: <name of the benchmark>
-        developer: <developing individual or organization>
+        developer: <developing individual or group>
         date: <date of benchmark creation>
         version: <version number>
-        type: <behavioral or neural>
+        type: <behavioral (tests against behavioral data), neural (tests against neural data), or engineering (others, typically test on ground-truth)>
         description: <a short summary description>
         license: <license details>
         questions: <where to send questions>
-        citations: <citation information if relevant>
+        references: <citation information if relevant>
 
       experiment:
-        task: <list of ArtificialSubject task values>
-        recording: <ArtificialSubject Recording type>
+        task: <list of ArtificialSubject task value(s) if any>
+        recording: <ArtificialSubject Recording type(s) if any>
         experiment_card: <reference any existing experiment cards>
-        bidirectionality: <unidirectional/bidirectional>
+        bidirectionality: <(if relevant) unidirectional/bidirectional: whether bidirectionality was used to obtain e.g., internal recordings of the model>
         contextualization: <if contextualized, what preceding context was used>
 
       data:
         accessibility: <public or private>
         measurement_type: <behavioral/neural and modality, e.g. neural; fMRI
-        granularity: <neural data granularity>
-        method: <how was the data obtained>
+        granularity: <neural data granularity, e.g. whether there is any aggregation such as fROIs>
+        method: <how was the data obtained e.g. # of participants, demographics, # of unique items, reps per item, etc.>
         data_card: <reference any existing data cards>
         references: <abbreviated Bibtex>
 
       metric:
-        mapping: <e.g., RidgeCV, LinReg, RSA>
         metric: <e.g. PearsonR, accuracy>
+        mapping: <how model predictions are mapped to neural data if at all, e.g., RidgeCV, LinReg, RSA>
         metric_card: <reference any existing metric cards>
         error_estimation: <methods used for estimating errors>
 

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -338,6 +338,117 @@ For instance, the following is an excerpt from the
         assert ceiling.raw.median('split') == ceiling
         assert ceiling.uncorrected_consistencies.median('split') < ceiling
 
+Benchmark Card
+--------------
+
+Please include a :code:`README.md` file along with your benchmark to aid users with understanding and implementation.
+As part of your README.md file, please include a YAML section using the following format as a guideline:
+
+.. code-block:: yaml
+    ---
+    benchmark details:
+        developer: MIT Computational Psycholinguistics Lab
+        date: 2020
+        questions: mitcpllab@gmail.com
+        version: 1.0
+        type: behavioral
+        license: MIT
+        citations: |
+        @inproceedings{hu-etal-2020-systematic,
+        title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
+        author = "Hu, Jennifer and Gauthier, Jon and Qian, Peng and Wilcox, Ethan and Levy, Roger",
+        booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+        year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-main.158", pages = "1725--1744"}
+        @inproceedings{gauthier-etal-2020-syntaxgym,
+        title = "{S}yntax{G}ym: An Online Platform for Targeted Evaluation of Language Models",
+        author = "Gauthier, Jon and Hu, Jennifer and Wilcox, Ethan and Qian, Peng and Levy, Roger",
+        booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
+        year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-demos.10", pages = "70--76"}
+
+    experiment:
+        task: Currently either "next_word" or "reading_times"
+        recording: fMRI
+        modelcard: NA
+        bidirectionality: NA
+        contextualization: NA
+
+    data:
+        accessibility: public
+        modality: behavioral
+        granularity: NA
+        method: NA
+        references: |
+         Wilcox E. Levy R. & Futrell R. (2019). Hierarchical representation in neural language models: Suppression and
+        recovery of expectations.
+        location: in the benchmark, as a json
+
+    description: |
+        Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark
+        feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for
+        some language models. To succeed in generating expectations about how sentences will continue in the context of
+        multiple center embedding, a model must maintain a representation not only of what words appear in the preceding
+        context but also of the order of those words, and must predict that upcoming words occur in the appropriate order.
+        In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
+
+    metric:
+        mapping: N/A
+        metric: accuracy
+        crossvalstrat: N/A
+        crossvalsplitcoord: N/A
+
+    ethical_considerations: N/A
+
+    recommendations: N/A
+
+    example_usage:
+        example: see test_integration.py for example usage
+        note: |
+        To use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html)
+        ```
+        from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
+        from brainscore_language import load_model
+        model = load_model("distilgpt2")
+        benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
+        score = benchmark(model)
+        ```
+    ---
+
+For instance, the following is an excerpt from the
+`Futrell2018 tests <https://github.com/brain-score/language/blob/85afdae5294d0613fb51c33333aa76c52fc0849e/brainscore_language/benchmarks/futrell2018/test.py>`_:
+
+.. code-block:: python
+
+    from brainscore_language import ArtificialSubject, load_benchmark
+
+    class DummyModel(ArtificialSubject):
+        def __init__(self, reading_times):
+            self.reading_times = reading_times
+
+        def digest_text(self, stimuli):
+            return {'behavior': BehavioralAssembly(self.reading_times, coords={
+                                        'context': ('presentation', stimuli),
+                                        'stimulus_id': ('presentation', np.arange(len(stimuli)))},
+                                    dims=['presentation'])}
+
+        def start_behavioral_task(self, task: ArtificialSubject.Task):
+            if task != ArtificialSubject.Task.reading_times:
+                raise NotImplementedError()
+
+    def test_dummy_bad():
+        benchmark = load_benchmark('Futrell2018-pearsonr')
+        reading_times = RandomState(0).random(10256)
+        dummy_model = DummyModel(reading_times=reading_times)
+        score = benchmark(dummy_model)
+        assert score == approx(0.0098731 / .858, abs=0.001)
+
+    def test_ceiling():
+        benchmark = load_benchmark('Futrell2018-pearsonr')
+        ceiling = benchmark.ceiling
+        assert ceiling == approx(.858, abs=.0005)
+        assert ceiling.raw.median('split') == ceiling
+        assert ceiling.uncorrected_consistencies.median('split') < ceiling
+
+
 4. Submit to Brain-Score
 ========================
 

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -342,7 +342,7 @@ Benchmark Card Creation
 -----------------------
 
 Please include a :code:`README.md` file along with your benchmark to aid users with understanding and implementation.
-As part of your README.md file, please include a YAML "Benchmark Card" section, detailing your benchmark, and using the
+As part of your :code:`README.md`, please include a YAML "Benchmark Card" section, detailing your benchmark, and using the
 following format as a guideline. (NOTE: For cases where multiple benchmarks are submitted in a single plugin; a single
 YAML could be appropriate for two very similar benchmarks, and separate YAMLs could be more fitting for dissimilar
 benchmarks. This is left as a decision for the creator).

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -338,79 +338,47 @@ For instance, the following is an excerpt from the
         assert ceiling.raw.median('split') == ceiling
         assert ceiling.uncorrected_consistencies.median('split') < ceiling
 
-Benchmark Card
---------------
+Benchmark Card Creation
+-----------------------
 
 Please include a :code:`README.md` file along with your benchmark to aid users with understanding and implementation.
 As part of your README.md file, please include a YAML section using the following format as a guideline:
 
 .. code-block:: yaml
     ---
-    benchmark details:
-        developer: MIT Computational Psycholinguistics Lab
-        date: 2020
-        questions: mitcpllab@gmail.com
-        version: 1.0
-        type: behavioral
-        license: MIT
-        citations: |
-        @inproceedings{hu-etal-2020-systematic,
-        title = "A Systematic Assessment of Syntactic Generalization in Neural Language Models",
-        author = "Hu, Jennifer and Gauthier, Jon and Qian, Peng and Wilcox, Ethan and Levy, Roger",
-        booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
-        year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-main.158", pages = "1725--1744"}
-        @inproceedings{gauthier-etal-2020-syntaxgym,
-        title = "{S}yntax{G}ym: An Online Platform for Targeted Evaluation of Language Models",
-        author = "Gauthier, Jon and Hu, Jennifer and Wilcox, Ethan and Qian, Peng and Levy, Roger",
-        booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
-        year = "2020", url = "https://www.aclweb.org/anthology/2020.acl-demos.10", pages = "70--76"}
+      benchmark_details:
+        developer: <developing individual or organization>
+        date: <date of benchmark creation>
+        questions: <where to send questions>
+        version: <version number>
+        type: <behavioral or neural>
+        license: <license details>
+        citations: <citation information if relevant>
 
-    experiment:
-        task: Currently either "next_word" or "reading_times"
-        recording: fMRI
-        modelcard: NA
-        bidirectionality: NA
-        contextualization: NA
+      experiment:
+        task: <list of ArtificialSubject task values>
+        recording: <ArtificialSubject Recording type>
+        experiment_card: <reference existing experiment cards>
+        bidirectionality: <unidirectional/bidirectional>
 
-    data:
-        accessibility: public
-        modality: behavioral
-        granularity: NA
-        method: NA
-        references: |
-         Wilcox E. Levy R. & Futrell R. (2019). Hierarchical representation in neural language models: Suppression and
-        recovery of expectations.
-        location: in the benchmark, as a json
+      data:
+        accessibility: <public or private>
+        modality: <behavioral/neural and modality, e.g. neural; fMRI
+        granularity: <neural data granularity>
+        method: <how was the data obtainede?>
+        references: <abbreviated Bibtex>
 
-    description: |
-        Center embedding, the ability to embed a phrase in the middle of another phrase of the same type, is a hallmark
-        feature of natural language syntax. Center-embedding creates nested dependencies, which could pose a challenge for
-        some language models. To succeed in generating expectations about how sentences will continue in the context of
-        multiple center embedding, a model must maintain a representation not only of what words appear in the preceding
-        context but also of the order of those words, and must predict that upcoming words occur in the appropriate order.
-        In this test suite we use verb transitivity and subject/verb plausibility to test model capabilities in this respect.
+      metric:
+        mapping: <e.g., RidgeCV, LinReg, RSA>
+        metric: <e.g. PearsonR, accuracy>
+        crossvalstrat: <cross validation stratification, e.g. passage>
+        crossvalsplitcoord: <cross validation split coordinate <e.g. sentence>
 
-    metric:
-        mapping: N/A
-        metric: accuracy
-        crossvalstrat: N/A
-        crossvalsplitcoord: N/A
+      ethical_considerations: <any relevant ethical consideration>
 
-    ethical_considerations: N/A
+      recommendations: <any relevant caveats and recommendations>
 
-    recommendations: N/A
-
-    example_usage:
-        example: see test_integration.py for example usage
-        note: |
-        To use your own suite specified as a [json file:](https://cpllab.github.io/syntaxgym-core/suite_json.html)
-        ```
-        from brainscore_language.benchmarks.syntaxgym import SyntaxGymSingleTSE
-        from brainscore_language import load_model
-        model = load_model("distilgpt2")
-        benchmark = SyntaxGymSingleTSE("path/to/my/syntaxgym/suite.json")
-        score = benchmark(model)
-        ```
+      example_usage: <one example should be in test_integration.py>
     ---
 
 For instance, the following is an excerpt from the

--- a/docs/source/modules/benchmark_tutorial.rst
+++ b/docs/source/modules/benchmark_tutorial.rst
@@ -345,7 +345,6 @@ Please include a :code:`README.md` file along with your benchmark to aid users w
 As part of your README.md file, please include a YAML section using the following format as a guideline:
 
 .. code-block:: yaml
-    ---
       benchmark_details:
         developer: <developing individual or organization>
         date: <date of benchmark creation>
@@ -379,7 +378,6 @@ As part of your README.md file, please include a YAML section using the followin
       recommendations: <any relevant caveats and recommendations>
 
       example_usage: <one example should be in test_integration.py>
-    ---
 
 4. Submit to Brain-Score
 ========================


### PR DESCRIPTION
This is just the README.md file for the syntaxgym benchmark.  After looking at the options for how to structure the yaml section, I decided to create a dictionary for each of the main headings (benchmark details, experiment, data, etc.) in the benchmark card.

If you look at the raw version it looks pretty neat, but the html version looks pretty sloppy (the key/value pairs within the dictionary are not each on their own lines).

Could you please let me know if the idea of using a dictionary for each heading is correct, and also if I've made an error in my yaml syntax that's resulting in a sloppy looking "yaml section" in the html version?  (p.s. this is my first time using yaml)