### PR TITLE
Prevent infinite `conda` scoring loops

### DIFF
--- a/brainscore_language/__init__.py
+++ b/brainscore_language/__init__.py
@@ -58,7 +58,7 @@ def _run_score(model_identifier: str, benchmark_identifier: str) -> Score:
     return score
 
 
-def score(model_identifier: str, benchmark_identifier: str) -> Score:
+def score(model_identifier: str, benchmark_identifier: str, conda_active: bool=False) -> Score:
     """
     Score the model referenced by the `model_identifier` on the benchmark referenced by the `benchmark_identifier`.
     The model needs to implement the :class:`~brainscore_language.artificial_subject.ArtificialSubject` interface
@@ -77,4 +77,4 @@ def score(model_identifier: str, benchmark_identifier: str) -> Score:
     """
     return wrap_score(__file__,
                       model_identifier=model_identifier, benchmark_identifier=benchmark_identifier,
-                      score_function=_run_score)
+                      score_function=_run_score, conda_active=conda_active)

--- a/brainscore_language/__main__.py
+++ b/brainscore_language/__main__.py
@@ -5,8 +5,8 @@ import fire
 from brainscore_language import score as _score_function
 
 
-def score(model_identifier: str, benchmark_identifier: str):
-    result = _score_function(model_identifier, benchmark_identifier)
+def score(model_identifier: str, benchmark_identifier: str, conda_active: bool=False):
+    result = _score_function(model_identifier, benchmark_identifier, conda_active)
     print(result)  # print instead of return because fire has issues with xarray objects
 
 


### PR DESCRIPTION
Prevents infinite loops invoked during `conda` scoring runs. Depends on brain-score/core [PR #27](https://github.com/brain-score/core/pull/27).