### PR TITLE
Fix GitHub Actions logic

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -171,7 +171,16 @@ jobs:
       - name: Auto Approve
         uses: hmarr/auto-approve-action@v3.1.0
 
-      - name: Auto Merge
+      - name: Auto Merge (GitHub submissions)
         uses: plm9606/automerge_actions@1.2.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-name: "automerge"
+          auto-delete: "true"
+
+      - name: Auto Merge (brain-score.org submissions)
+        uses: plm9606/automerge_actions@1.2.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-name: "automerge-web"
+          auto-delete: "true"

--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -102,16 +102,16 @@ jobs:
         id: add_email_to_pluginfo
         run: |
           echo "The PR author email is ${{ steps.getemail.outputs.email }}"
-          echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {author_email: ${{ steps.getemail.outputs.email }} }')"" >> $GITHUB_OUTPUT
+          echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {author_email: "'${{ steps.getemail.outputs.email }}'"}')"" >> $GITHUB_OUTPUT
 
   runscore:
     name: Score plugins
     runs-on: ubuntu-latest
-    needs: changes_models_or_benchmarks
+    needs: [changes_models_or_benchmarks, get_submitter_info]
     if: ${{ needs.changes_models_or_benchmarks.outputs.RUN_SCORE == 'True' }}
     env:
       PLUGIN_INFO: ${{ needs.get_submitter_info.outputs.PLUGIN_INFO }}
-      JENKINS_USER: ${{ secrets.JENKINS_USER }}
+      JENKINS_USER: ${{ secrets.JENKINS_USR }}
       JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
       JENKINS_TRIGGER: ${{ secrets.JENKINS_TRIGGER }}
     steps:


### PR DESCRIPTION
* Adds `automerge-web` label to merge job
* Fixes formatting in `bash` command to add `author_email`
* [Temporarily] reverts `JENKINS_USER` env var (unknown if works) to point to `JENKINS_USR` env var (confirmed to work) to ensure a complete testing run. 