### PR TITLE
Fixes bugs introduced by #108

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Auto Merge (GitHub submissions)
         uses: plm9606/automerge_actions@1.2.2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WORKFLOW_TOKEN }}
           label-name: "automerge"
           merge-method: "squash"
           auto-delete: "true"
@@ -179,7 +179,7 @@ jobs:
       - name: Auto Merge (brain-score.org submissions)
         uses: plm9606/automerge_actions@1.2.2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.WORKFLOW_TOKEN }}
           label-name: "automerge-web"
           merge-method: "squash"
           auto-delete: "true"

--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -14,11 +14,8 @@ name: Automatically merge plugin-only PRs
 
 
 on:
-  check_suite:
-    types: [completed]
   pull_request:
     types: [labeled]
-  workflow_dispatch:
   status:
 
 permissions: write-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,12 @@ install:
 script:
   - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
   - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
+after_success:
+  # trigger workflow to check if plugin is being added
+  - >
+    if $TRAVIS_PULL_REQUEST; then
+    curl -L -X POST \
+    -H 'Authorization: token '$GH_WORKFLOW_TRIGGER 
+    -d '{\"state\": \"success\", \"description\": \"Run automerge workflow\", \"context\": \"continuous-integration/travis"}' \
+    \"https://api.github.com/repos/brain-score/language/statuses/$TRAVIS_PULL_REQUEST_SHA\"
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,15 @@ install:
 script:
   - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
   - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
-after_success:
-  # trigger workflow to check if plugin is being added
-  - >
-    if $TRAVIS_PULL_REQUEST; then
-    curl -L -X POST \
-    -H 'Authorization: token '$GH_WORKFLOW_TRIGGER 
-    -d '{\"state\": \"success\", \"description\": \"Run automerge workflow\", \"context\": \"continuous-integration/travis"}' \
-    \"https://api.github.com/repos/brain-score/language/statuses/$TRAVIS_PULL_REQUEST_SHA\"
-    fi
+
+jobs:
+  include:
+    - stage: "Trigger automerge workflow"
+      # trigger workflow to check if plugin is being added
+      - >
+        if $TRAVIS_PULL_REQUEST; then
+        curl -L -X POST \
+        -H 'Authorization: token '$GH_WORKFLOW_TRIGGER 
+        -d '{\"state\": \"success\", \"description\": \"Run automerge workflow\", \"context\": \"continuous-integration/travis"}' \
+        \"https://api.github.com/repos/brain-score/language/statuses/$TRAVIS_PULL_REQUEST_SHA\"
+        fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: python
-python:
-  - "3.7"
-  - "3.8"
-  - "3.9"
+matrix:
+  include:
+    - name: 3.8 public
+      python: '3.8'
+    - name: 3.8 private
+      python: '3.8'
+      env: PRIVATE_ACCESS=1
+    - name: 3.9 public
+      python: '3.9'
+    - name: 3.9 private
+      python: '3.9'
+      env: PRIVATE_ACCESS=1
 install:
-  # fix setuptools for python 3.7, error in other versions https://github.com/pypa/setuptools/issues/3293
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.7* ]]; then
-    pip install "setuptools==60.5.0";
-    fi
   - python -m pip install -e ".[test]"
   # install conda for plugin runner
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -21,7 +25,8 @@ install:
   # install singularity for container models
   - conda install -yc conda-forge singularity
 script:
-  - pytest -m "not requires_gpu and not memory_intense and not slow and not travis_slow"
+  - if [ "$PRIVATE_ACCESS" = 1 ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pytest -m "private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
+  - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
   - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
 
 jobs:
@@ -29,7 +34,7 @@ jobs:
     - stage: "Trigger automerge workflow"
       # trigger workflow to check if plugin is being added
       - >
-        if $TRAVIS_PULL_REQUEST; then
+        if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
         curl -L -X POST \
         -H 'Authorization: token '$GH_WORKFLOW_TRIGGER 
         -d '{\"state\": \"success\", \"description\": \"Run automerge workflow\", \"context\": \"continuous-integration/travis"}' \

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -76,9 +76,10 @@ def run_scoring(args_dict: Dict[str, Union[str, List]]):
             models = new_models
             benchmarks = RunScoringEndpoint.ALL_PUBLIC
 
-    run_scoring_endpoint("language", args_dict["jenkins_id"], models,
-        benchmarks, args_dict["user_id"], "artificialsubject",
-        args_dict["public"], args_dict["competition"])
+    run_scoring_endpoint(domain="language", jenkins_id=args_dict["jenkins_id"], 
+        models=models, benchmarks=benchmarks, user_id=args_dict["user_id"], 
+        model_type="artificialsubject", public=args_dict["public"], 
+        competition=args_dict["competition"])
 
 
 def parse_args() -> argparse.Namespace:

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -55,10 +55,6 @@ def _get_ids(args_dict: Dict[str, Union[str, List]], key: str) -> Union[List, st
     return args_dict[key] if key in args_dict else None
 
 
-def _clean_args(remove_keys: List[str], args_dict: Dict[str, Union[str, List]]) -> Dict[str, Union[str, List]]:
-    return {k: v for k, v in args_dict.items() if k not in remove_keys}  # preserve other keys, e.g. `run_score`
-
-
 def run_scoring(args_dict: Dict[str, Union[str, List]]):
     """ prepares parameters for the `run_scoring_endpoint`. """
     new_models = _get_ids(args_dict, 'new_models')

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -88,17 +88,17 @@ def parse_args() -> argparse.Namespace:
                         help='The id of the current jenkins run')
     parser.add_argument('public', type=bool, nargs='?', default=True,
                         help='Public (or private) submission?')
-    parser.add_argument('--competition', type=str, nargs='?', const=None, default=None,
+    parser.add_argument('--competition', type=str, nargs='?', default=None,
                         help='Name of competition for which submission is being scored')
-    parser.add_argument('--user_id', type=int, nargs='?', const=None, default=None,
+    parser.add_argument('--user_id', type=int, nargs='?', default=None,
                         help='ID of submitting user in the postgres DB')
-    parser.add_argument('--author_email', type=str, nargs='?', const=None, default=None,
+    parser.add_argument('--author_email', type=str, nargs='?', default=None,
                         help='email associated with PR author GitHub username')
-    parser.add_argument('--specified_only', type=bool, nargs='?', const=True, default=False,
+    parser.add_argument('--specified_only', type=bool, nargs='?', default=False,
                         help='Only score the plugins specified by new_models and new_benchmarks')
-    parser.add_argument('--new_models', type=str, nargs='*', const=None, default=None,
+    parser.add_argument('--new_models', type=str, nargs='*', default=None,
                         help='The identifiers of newly submitted models to score on all benchmarks')
-    parser.add_argument('--new_benchmarks', type=str, nargs='*', const=None, default=None,
+    parser.add_argument('--new_benchmarks', type=str, nargs='*', default=None,
                         help='The identifiers of newly submitted benchmarks on which to score all models')
     args, remaining_args = parser.parse_known_args()
 

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -93,22 +93,22 @@ def parse_args() -> argparse.Namespace:
                         help='The id of the current jenkins run')
     parser.add_argument('domain', type=str,
                         help='The submission domain (vision or language)')
-    parser.add_argument('user_id', type=int, nargs='?', default=None,
-                        help='ID of submitting user in the postgres DB')
-    parser.add_argument('author_email', type=str, nargs='?', default=None,
-                        help='email associated with PR author GitHub username')
     parser.add_argument('model_type', type=str, nargs='?', default='artificialsubject',
                         help='Type of model to score')
     parser.add_argument('public', type=bool, nargs='?', default=True,
                         help='Public (or private) submission?')
-    parser.add_argument('competition', type=str, nargs='?', default=None,
+    parser.add_argument('--competition', type=str, nargs='?', const=None, default=None,
                         help='Name of competition for which submission is being scored')
-    parser.add_argument('--new_models', type=str, nargs='*', default=None,
-                        help='The identifiers of newly submitted models to score on all benchmarks')
-    parser.add_argument('--new_benchmarks', type=str, nargs='*', default=None,
-                        help='The identifiers of newly submitted benchmarks on which to score all models')
-    parser.add_argument('--specified_only', type=bool, nargs='?', default=False,
+    parser.add_argument('--user_id', type=int, nargs='?', const=None, default=None,
+                        help='ID of submitting user in the postgres DB')
+    parser.add_argument('--author_email', type=str, nargs='?', const=None, default=None,
+                        help='email associated with PR author GitHub username')
+    parser.add_argument('--specified_only', type=bool, nargs='?', const=True, default=False,
                         help='Only score the plugins specified by new_models and new_benchmarks')
+    parser.add_argument('--new_models', type=str, nargs='*', const=None, default=None,
+                        help='The identifiers of newly submitted models to score on all benchmarks')
+    parser.add_argument('--new_benchmarks', type=str, nargs='*', const=None, default=None,
+                        help='The identifiers of newly submitted benchmarks on which to score all models')
     args, remaining_args = parser.parse_known_args()
 
     return args

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -60,39 +60,35 @@ def _clean_args(remove_keys: List[str], args_dict: Dict[str, Union[str, List]]) 
 
 
 def run_scoring(args_dict: Dict[str, Union[str, List]]):
-    """ prepares `args_dict` as parameters for the `run_scoring_endpoint`. """
+    """ prepares parameters for the `run_scoring_endpoint`. """
     new_models = _get_ids(args_dict, 'new_models')
     new_benchmarks = _get_ids(args_dict, 'new_benchmarks')
 
     if args_dict['specified_only']:
         assert len(new_models) > 0, "No models specified"
         assert len(new_benchmarks) > 0, "No benchmarks specified"
-        args_dict['models'] = new_models
-        args_dict['benchmarks'] = new_benchmarks
+        models = new_models
+        benchmarks = new_benchmarks
     else:
         if new_models and new_benchmarks:
-            args_dict['models'] = RunScoringEndpoint.ALL_PUBLIC
-            args_dict['benchmarks'] = RunScoringEndpoint.ALL_PUBLIC
+            models = RunScoringEndpoint.ALL_PUBLIC
+            benchmarks = RunScoringEndpoint.ALL_PUBLIC
         elif new_benchmarks:
-            args_dict['models'] = RunScoringEndpoint.ALL_PUBLIC
-            args_dict['benchmarks'] = new_benchmarks
+            models = RunScoringEndpoint.ALL_PUBLIC
+            benchmarks = new_benchmarks
         elif new_models:
-            args_dict['models'] = new_models
-            args_dict['benchmarks'] = RunScoringEndpoint.ALL_PUBLIC
+            models = new_models
+            benchmarks = RunScoringEndpoint.ALL_PUBLIC
 
-    new_args = _clean_args(['new_benchmarks', 'new_models', 
-                            'author_email', 'specified_only'], args_dict)
-    new_args["domain"] = "language"
-
-    run_scoring_endpoint(**new_args)
+    run_scoring_endpoint("language", args_dict["jenkins_id"], models,
+        benchmarks, args_dict["user_id"], "artificialsubject",
+        args_dict["public"], args_dict["competition"])
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('jenkins_id', type=int,
                         help='The id of the current jenkins run')
-    parser.add_argument('model_type', type=str, nargs='?', default='artificialsubject',
-                        help='Type of model to score')
     parser.add_argument('public', type=bool, nargs='?', default=True,
                         help='Public (or private) submission?')
     parser.add_argument('--competition', type=str, nargs='?', const=None, default=None,

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -91,8 +91,6 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('jenkins_id', type=int,
                         help='The id of the current jenkins run')
-    parser.add_argument('domain', type=str,
-                        help='The submission domain (vision or language)')
     parser.add_argument('model_type', type=str, nargs='?', default='artificialsubject',
                         help='Type of model to score')
     parser.add_argument('public', type=bool, nargs='?', default=True,

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -14,6 +14,7 @@ from brainscore_language.submission.endpoints import run_scoring
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.private
 class TestRunScoring:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Addresses the following items introduced by #108:
 
* The [automerge workflow](https://github.com/brain-score/language/compare/main...kvf/submission_cleanup#diff-9a16e89964a9620853f1fd65df9254611dde1da223e4d0e0af85cbd87f452eab) cannot trigger in `main` on `check_suite` completion from a PR. After a successful Travis run on a PR, [Travis now triggers](https://github.com/brain-score/language/compare/main...kvf/submission_cleanup#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485) the automerge workflow directly via a `status` update.

* For security reasons, GitHub Actions workflows cannot be triggered by jobs in other workflows via the default `GITHUB_TOKEN`, so the automerge job cannot catalyze the scoring workflow using this token. `GITHUB_TOKEN` has now been updated to `WORKFLOW_TOKEN`, which was created for use in these workflows and owned by the Brain-Score organization.

* This PR also adds more flexibility in specifying scoring parameters, which fixes an issue with out-of-order positional params.