### PR TITLE
If PR from fork, do not test `private_access` or entire `tests/test_submission` dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda install -yc conda-forge singularity
 script:
   - if [ "$PRIVATE_ACCESS" = 1 ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pytest -m "private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
-  - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
+  - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and not requires_gpu and not memory_intense and not slow and not travis_slow" --ignore "tests/test_submission"; fi
   - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # install singularity for container models
   - conda install -yc conda-forge singularity
 script:
-  - if [ "$PRIVATE_ACCESS" = 1 ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then pytest -m "private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
+  - if [ "$PRIVATE_ACCESS" = 1 ] && [ -z "${GITHUB_TOKEN}" ]; then pytest -m "private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
   - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and not requires_gpu and not memory_intense and not slow and not travis_slow" --ignore "tests/test_submission"; fi
   - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # install singularity for container models
   - conda install -yc conda-forge singularity
 script:
-  - if [ "$PRIVATE_ACCESS" = 1 ] && [ -z "${GITHUB_TOKEN}" ]; then pytest -m "private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
+  - if [ "$PRIVATE_ACCESS" = 1 ] && [ -n "${GITHUB_TOKEN}" ]; then pytest -m "private_access and not requires_gpu and not memory_intense and not slow and not travis_slow"; fi
   - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and not requires_gpu and not memory_intense and not slow and not travis_slow" --ignore "tests/test_submission"; fi
   - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
 

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 from pytest import approx
 
-
 """ the mock import has to be before importing endpoints so that the database is properly mocked """
 from .mock_config import test_database
 
@@ -12,11 +11,11 @@ from brainscore_core.submission.database import connect_db
 from brainscore_core.submission.database_models import clear_schema
 from brainscore_language.submission.endpoints import run_scoring
 
-pytestmark = pytest.mark.private_access
 
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.private_access
 class TestRunScoring:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
PRs that originate from forks don't have access to encrypted environment variables in Travis, so tests that rely on those variables are excluded in this case.