### PR TITLE
fix a bug where both new and old tokenize methods were used for gpt

### DIFF
--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -26,7 +26,6 @@ class HuggingfaceSubject(ArtificialSubject):
             region_layer_mapping: dict,
             model=None,
             tokenizer=None,
-            tokenization_method: str = 'new',
             task_heads: Union[None, Dict[ArtificialSubject.Task, Callable]] = None,
     ):
         """
@@ -35,7 +34,6 @@ class HuggingfaceSubject(ArtificialSubject):
                 This can be left empty, but the model will not be able to be tested on neural benchmarks
             :param model: the model to run inference from. Using `AutoModelForCausalLM.from_pretrained` if `None`.
             :param tokenizer: the model's associated tokenizer. Using `AutoTokenizer.from_pretrained` if `None`.
-            :param tokenization_method: whether to use the new or old tokenization method.
             :param task_heads: a mapping from one or multiple tasks
                 (:class:`~brainscore_language.artificial_subject.ArtificialSubject.Task`) to a function outputting the
                 requested task output, given the basemodel's base output
@@ -50,7 +48,8 @@ class HuggingfaceSubject(ArtificialSubject):
         self.tokenizer = tokenizer if tokenizer is not None else AutoTokenizer.from_pretrained(self.model_id,
                                                                                                truncation_side='left')
         self.current_tokens = None  # keep track of current tokens
-        self._tokenization_method = tokenization_method
+        self._tokenizer_returns_overflow: Union[None, bool] = None
+        """ whether the tokenizer can return overflowing tokens. `None` initially before inferring tokenizer type """
 
         self.neural_recordings: List[Tuple] = []  # list of `(recording_target, recording_type)` tuples to record
         self.behavioral_task: Union[None, ArtificialSubject.Task] = None
@@ -140,18 +139,40 @@ class HuggingfaceSubject(ArtificialSubject):
 
         return context
 
-    def _tokenize_newer_tokenizers(self, context: str, num_previous_context_tokens: int) -> Tuple[BatchEncoding, int]:
-        context_tokens = self.tokenizer(
-            context, truncation=True, return_tensors="pt",
-            return_overflowing_tokens=True,
-        )
-        context_tokens.to(self.device)
+    def _tokenize(self, context, num_previous_context_tokens: int) -> Tuple[BatchEncoding, int]:
+        """
+        Tokenizes the context, keeping track of the newly added tokens in `self.current_tokens`
+        """
+        tokenizer_kwargs = dict()
+        if self._tokenizer_returns_overflow is None:  # first attempt of tokenizing, figure out which kwargs to use
+            try:
+                # First try method for 'older' tokenizers such as `GPT2TokenizerFast` that are not capable of
+                # returning overflowing tokens directly. Try this first because this method will fail for
+                # 'newer' tokenizers whereas the 'newer' method might work for some inputs, but will fail eventually.
+                self._tokenizer_returns_overflow = False
+                result = self._tokenize_overflow_aware(context, num_previous_context_tokens)
+            except ValueError:
+                self._tokenizer_returns_overflow = True
+                result = self._tokenize_overflow_aware(context, num_previous_context_tokens)
+            self._logger.debug(f"Using tokenizer_returns_overflow={self._tokenizer_returns_overflow}")
+            return result
+
+        # tokenization method has already been set at this point, do not change anymore
+        return self._tokenize_overflow_aware(context, num_previous_context_tokens)
+
+    def _tokenize_overflow_aware(self, context, num_previous_context_tokens: int) -> Tuple[BatchEncoding, int]:
+        context_tokens = self.tokenizer(context, truncation=True, return_tensors="pt",
+                                        return_overflowing_tokens=self._tokenizer_returns_overflow)
+
         # keep track of tokens in current `text_part`
-        if getattr(context_tokens, 'overflowing_tokens', None) is not None:
-            overflowing_encoding: list = np.array(context_tokens.overflowing_tokens.cpu())
+        num_overflowing = 0
+        if self._tokenizer_returns_overflow and getattr(context_tokens, 'overflowing_tokens', None) is not None:
+            overflowing_encoding = np.array(context_tokens.overflowing_tokens)
             num_overflowing = sum(len(overflow) for overflow in overflowing_encoding)
-        else:
-            num_overflowing = 0
+        elif not self._tokenizer_returns_overflow:  # 'older' gpt-style tokenizers, e.g. `GPT2TokenizerFast`
+            overflowing_encoding: list = np.array(context_tokens.encodings).item().overflowing
+            num_overflowing = 0 if not overflowing_encoding else sum(len(overflow) for overflow in overflowing_encoding)
+
         self.current_tokens = {key: value[..., num_previous_context_tokens - num_overflowing:]
                                for key, value in context_tokens.items()}
         num_new_context_tokens = context_tokens['input_ids'].shape[-1] + num_overflowing
@@ -161,31 +182,8 @@ class HuggingfaceSubject(ArtificialSubject):
             context_tokens.pop('num_truncated_tokens')
         if 'overflow_to_sample_mapping' in context_tokens:
             context_tokens.pop('overflow_to_sample_mapping')
-        return context_tokens, num_new_context_tokens
-
-    def _tokenize_older_tokenizers(self, context: str, num_previous_context_tokens: int) -> Tuple[BatchEncoding, int]:
-        # at least gpt2 and distillgpt2 can only work with this way but not general "return_overflowing_tokens"
-        # possibly a bug in these two tokenizers
-        context_tokens = self.tokenizer(context, truncation=True, return_tensors="pt")
         context_tokens.to(self.device)
-        # keep track of tokens in current `text_part`
-        overflowing_encoding: list = np.array(context_tokens.encodings).item().overflowing
-        num_overflowing = 0 if not overflowing_encoding else sum(len(overflow) for overflow in overflowing_encoding)
-        self.current_tokens = {key: value[..., num_previous_context_tokens - num_overflowing:]
-                               for key, value in context_tokens.items()}
-        num_new_context_tokens = context_tokens['input_ids'].shape[-1] + num_overflowing
         return context_tokens, num_new_context_tokens
-
-    def _tokenize(self, context, num_previous_context_tokens):
-        """
-        Tokenizes the context, keeping track of the newly added tokens in `self.current_tokens`
-        """
-        if self._tokenization_method == 'new':
-            return self._tokenize_newer_tokenizers(context, num_previous_context_tokens)
-        elif self._tokenization_method == 'old':
-            return self._tokenize_older_tokenizers(context, num_previous_context_tokens)
-        else:
-            raise ValueError(f"Invalid tokenization method specified: {self._tokenization_method}")
 
     def _setup_hooks(self):
         """ set up the hooks for recording internal neural activity from the model (aka layer activations) """

--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -9,7 +9,7 @@ import xarray as xr
 from numpy.core import defchararray
 from torch.utils.hooks import RemovableHandle
 from tqdm import tqdm
-from transformers import AutoModelForCausalLM, AutoTokenizer, BatchEncoding, GPT2TokenizerFast
+from transformers import AutoModelForCausalLM, AutoTokenizer, BatchEncoding
 from transformers.modeling_outputs import CausalLMOutput
 from typing import Union, List, Tuple, Dict, Callable
 

--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -48,7 +48,7 @@ class HuggingfaceSubject(ArtificialSubject):
         self.tokenizer = tokenizer if tokenizer is not None else AutoTokenizer.from_pretrained(self.model_id,
                                                                                                truncation_side='left')
         self.current_tokens = None  # keep track of current tokens
-        self.tokenization_method: Union[None, str] = None  # whether to use old or new tokenization. `None` initially
+        self._tokenization_method: Union[None, str] = None  # whether to use old or new tokenization. `None` initially
 
         self.neural_recordings: List[Tuple] = []  # list of `(recording_target, recording_type)` tuples to record
         self.behavioral_task: Union[None, ArtificialSubject.Task] = None
@@ -178,21 +178,21 @@ class HuggingfaceSubject(ArtificialSubject):
         """
         Tokenizes the context, keeping track of the newly added tokens in `self.current_tokens`
         """
-        if self.tokenization_method is None:
+        if self._tokenization_method is None:
             # first attempt of tokenizing, figure out which method to use
             try:
-                self.tokenization_method = 'new'
+                self._tokenization_method = 'new'
                 result = self._tokenize_newer_tokenizers(context, num_previous_context_tokens)
             except ValueError:
-                self.tokenization_method = 'old'
+                self._tokenization_method = 'old'
                 result = self._tokenize_older_tokenizers(context, num_previous_context_tokens)
-            self._logger.debug(f"Using tokenization_method '{self.tokenization_method}'")
+            self._logger.debug(f"Using tokenization_method '{self._tokenization_method}'")
             return result
 
         # tokenization method has already been set at this point, do not change anymore
-        elif self.tokenization_method == 'new':
+        elif self._tokenization_method == 'new':
             return self._tokenize_newer_tokenizers(context, num_previous_context_tokens)
-        elif self.tokenization_method == 'old':
+        elif self._tokenization_method == 'old':
             return self._tokenize_older_tokenizers(context, num_previous_context_tokens)
 
     def _setup_hooks(self):

--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -182,10 +182,12 @@ class HuggingfaceSubject(ArtificialSubject):
             # first attempt of tokenizing, figure out which method to use
             try:
                 self.tokenization_method = 'new'
-                return self._tokenize_newer_tokenizers(context, num_previous_context_tokens)
+                result = self._tokenize_newer_tokenizers(context, num_previous_context_tokens)
             except ValueError:
                 self.tokenization_method = 'old'
-                return self._tokenize_older_tokenizers(context, num_previous_context_tokens)
+                result = self._tokenize_older_tokenizers(context, num_previous_context_tokens)
+            self._logger.debug(f"Using tokenization_method '{self.tokenization_method}'")
+            return result
 
         # tokenization method has already been set at this point, do not change anymore
         elif self.tokenization_method == 'new':

--- a/brainscore_language/models/gpt/__init__.py
+++ b/brainscore_language/models/gpt/__init__.py
@@ -5,18 +5,14 @@ from brainscore_language.model_helpers.huggingface import HuggingfaceSubject
 # layer assignment based on choosing the maximally scoring layer on Pereira2018-encoding from
 # https://github.com/mschrimpf/neural-nlp/blob/master/precomputed-scores.csv
 
-model_registry['distilgpt2'] = lambda: HuggingfaceSubject(
-    model_id='distilgpt2', tokenization_method='old', region_layer_mapping={
-        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.5'})
+model_registry['distilgpt2'] = lambda: HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={
+    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.5'})
 
-model_registry['gpt2-xl'] = lambda: HuggingfaceSubject(
-    model_id='gpt2-xl', tokenization_method='old', region_layer_mapping={
-        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.43'})
+model_registry['gpt2-xl'] = lambda: HuggingfaceSubject(model_id='gpt2-xl', region_layer_mapping={
+    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.43'})
 
-model_registry['gpt-neo-2.7B'] = lambda: HuggingfaceSubject(
-    model_id='EleutherAI/gpt-neo-2.7B', tokenization_method='old', region_layer_mapping={
-        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.31'})
+model_registry['gpt-neo-2.7B'] = lambda: HuggingfaceSubject(model_id='EleutherAI/gpt-neo-2.7B', region_layer_mapping={
+    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.31'})
 
-model_registry['gpt-neo-1.3B'] = lambda: HuggingfaceSubject(
-    model_id='EleutherAI/gpt-neo-1.3B', tokenization_method='old', region_layer_mapping={
-        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.18'})
+model_registry['gpt-neo-1.3B'] = lambda: HuggingfaceSubject(model_id='EleutherAI/gpt-neo-1.3B', region_layer_mapping={
+    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.18'})

--- a/brainscore_language/models/gpt/__init__.py
+++ b/brainscore_language/models/gpt/__init__.py
@@ -5,14 +5,18 @@ from brainscore_language.model_helpers.huggingface import HuggingfaceSubject
 # layer assignment based on choosing the maximally scoring layer on Pereira2018-encoding from
 # https://github.com/mschrimpf/neural-nlp/blob/master/precomputed-scores.csv
 
-model_registry['distilgpt2'] = lambda: HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={
-    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.5'})
+model_registry['distilgpt2'] = lambda: HuggingfaceSubject(
+    model_id='distilgpt2', tokenization_method='old', region_layer_mapping={
+        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.5'})
 
-model_registry['gpt2-xl'] = lambda: HuggingfaceSubject(model_id='gpt2-xl', region_layer_mapping={
-    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.43'})
+model_registry['gpt2-xl'] = lambda: HuggingfaceSubject(
+    model_id='gpt2-xl', tokenization_method='old', region_layer_mapping={
+        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.43'})
 
-model_registry['gpt-neo-2.7B'] = lambda: HuggingfaceSubject(model_id='EleutherAI/gpt-neo-2.7B', region_layer_mapping={
-    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.31'})
+model_registry['gpt-neo-2.7B'] = lambda: HuggingfaceSubject(
+    model_id='EleutherAI/gpt-neo-2.7B', tokenization_method='old', region_layer_mapping={
+        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.31'})
 
-model_registry['gpt-neo-1.3B'] = lambda: HuggingfaceSubject(model_id='EleutherAI/gpt-neo-1.3B', region_layer_mapping={
-    ArtificialSubject.RecordingTarget.language_system: 'transformer.h.18'})
+model_registry['gpt-neo-1.3B'] = lambda: HuggingfaceSubject(
+    model_id='EleutherAI/gpt-neo-1.3B', tokenization_method='old', region_layer_mapping={
+        ArtificialSubject.RecordingTarget.language_system: 'transformer.h.18'})

--- a/tests/test_model_helpers/test_huggingface.py
+++ b/tests/test_model_helpers/test_huggingface.py
@@ -7,44 +7,42 @@ from pytest import approx
 from brainscore_language.artificial_subject import ArtificialSubject
 from brainscore_language.model_helpers.huggingface import HuggingfaceSubject
 
-logging.basicConfig(level=logging.INFO)
+_logger = logging.getLogger(__name__)
 
 
 class TestNextWord:
-    @pytest.mark.parametrize('model_identifier, tokenization_method, expected_next_word', [
-        pytest.param('bert-base-uncased', 'new', '.', marks=pytest.mark.memory_intense),
-        pytest.param('gpt2-xl', 'old', 'jumps', marks=pytest.mark.memory_intense),
-        ('distilgpt2', 'old', 'es'),
+    @pytest.mark.parametrize('model_identifier, expected_next_word', [
+        pytest.param('bert-base-uncased', '.', marks=pytest.mark.memory_intense),
+        pytest.param('gpt2-xl', 'jumps', marks=pytest.mark.memory_intense),
+        ('distilgpt2', 'es'),
     ])
-    def test_single_string(self, model_identifier, tokenization_method, expected_next_word):
+    def test_single_string(self, model_identifier, expected_next_word):
         """
         This is a simple test that takes in text = 'the quick brown fox', and tests the next word.
         This test is a stand-in prototype to check if our model definitions are correct.
         """
 
-        model = HuggingfaceSubject(model_id=model_identifier, tokenization_method=tokenization_method,
-                                   region_layer_mapping={})
+        model = HuggingfaceSubject(model_id=model_identifier, region_layer_mapping={})
         text = 'the quick brown fox'
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.next_word)
         next_word = model.digest_text(text)['behavior'].values
         assert next_word == expected_next_word
 
-    @pytest.mark.parametrize('model_identifier, tokenization_method, expected_next_words', [
-        pytest.param('bert-base-uncased', 'new', ['.', '.', '.'], marks=pytest.mark.memory_intense),
-        pytest.param('gpt2-xl', 'old', ['jumps', 'the', 'dog'], marks=pytest.mark.memory_intense),
-        ('distilgpt2', 'old', ['es', 'the', 'fox']),
+    @pytest.mark.parametrize('model_identifier, expected_next_words', [
+        pytest.param('bert-base-uncased', ['.', '.', '.'], marks=pytest.mark.memory_intense),
+        pytest.param('gpt2-xl', ['jumps', 'the', 'dog'], marks=pytest.mark.memory_intense),
+        ('distilgpt2', ['es', 'the', 'fox']),
     ])
-    def test_list_input(self, model_identifier, tokenization_method, expected_next_words):
+    def test_list_input(self, model_identifier, expected_next_words):
         """
         This is a simple test that takes in text = ['the quick brown fox', 'jumps over', 'the lazy'], and tests the
         next word for each text part in the list.
         This test is a stand-in prototype to check if our model definitions are correct.
         """
-        model = HuggingfaceSubject(model_id=model_identifier, tokenization_method=tokenization_method,
-                                   region_layer_mapping={})
+        model = HuggingfaceSubject(model_id=model_identifier, region_layer_mapping={})
         text = ['the quick brown fox', 'jumps over', 'the lazy']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.next_word)
         next_words = model.digest_text(text)['behavior']
         np.testing.assert_array_equal(next_words, expected_next_words)
@@ -55,7 +53,7 @@ class TestNextWord:
         text = 'lorem ipsum dolor sit amet'.split() * 205
         assert len(text) > 1024
         text = ' '.join(text)
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         model.start_behavioral_task(task=ArtificialSubject.Task.next_word)
         next_words = model.digest_text(text)['behavior']
         assert len(next_words) == 1
@@ -65,29 +63,29 @@ class TestNextWord:
         # ensure that this is handled gracefully
         from brainscore_language import load_benchmark
         benchmark = load_benchmark('Wikitext-accuracy')
-        benchmark.data = benchmark.data[0:2] # test on subset for speed
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        benchmark.data = benchmark.data[0:2]  # test on subset for speed
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         score = benchmark(model)
         assert score == 0
 
 
 class TestReadingTimes:
     def test_single_word(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_time = model.digest_text('the')['behavior']
         assert np.isnan(reading_time)
 
     def test_multiple_words(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_time = model.digest_text('the quick brown fox')['behavior']
         assert reading_time == approx(44.06524, abs=0.001)
 
     def test_list_input(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         text = ['the', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_times = model.digest_text(text)['behavior']
         np.testing.assert_allclose(
@@ -95,26 +93,26 @@ class TestReadingTimes:
             atol=0.0001)
 
     def test_multitoken_words(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         text = ['beekeepers', 'often', 'go', 'beekeeping']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_times = model.digest_text(text)['behavior']
         np.testing.assert_allclose(
             reading_times, [16.1442, 10.4003, 6.6620, 16.0906 + 1.3748], atol=0.0001)
 
     def test_multiword_list_input(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         text = ['the quick brown fox', 'jumps over', 'the lazy']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_times = model.digest_text(text)['behavior']
         np.testing.assert_allclose(reading_times, [44.06524, 14.554907, 14.064276], atol=0.0001)
 
     def test_punct(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={})
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={})
         text = ['fox', 'is', 'quick.']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_times = model.digest_text(text)['behavior']
         np.testing.assert_allclose(
@@ -130,7 +128,7 @@ class TestReadingTimes:
         # expected tokenization:
         # ['<s>', '▁The', '▁quick', '▁brown', '▁', 'fox', '▁jump', 's', '▁over', '▁the',
         #  '▁la', 'zy', '▁dog', '</s>']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_behavioral_task(task=ArtificialSubject.Task.reading_times)
         reading_times = model.digest_text(text)['behavior']
         np.testing.assert_allclose(
@@ -145,10 +143,10 @@ class TestNeural:
         This test is a stand-in prototype to check if our model definitions are correct.
         """
 
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={
             ArtificialSubject.RecordingTarget.language_system: 'transformer.h.0.ln_1'})
         text = ['the quick brown fox', 'jumps over', 'the lazy dog']
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_neural_recording(recording_target=ArtificialSubject.RecordingTarget.language_system,
                                      recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
@@ -163,25 +161,25 @@ class TestNeural:
         indexed by `representation_layer` has 1 text presentation and 768 neurons. This test is a stand-in prototype to
         check if our model definitions are correct.
         """
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={
             ArtificialSubject.RecordingTarget.language_system: 'transformer.h.0.ln_1'})
         text = 'the quick brown fox'
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_neural_recording(recording_target=ArtificialSubject.RecordingTarget.language_system,
                                      recording_type=ArtificialSubject.RecordingType.fMRI)
         representations = model.digest_text(text)['neural']
         assert len(representations['presentation']) == 1
         assert representations['stimulus'].squeeze() == text
         assert len(representations['neuroid']) == 768
-        logging.info(f'representation shape is correct: {representations.shape}')
+        _logger.info(f'representation shape is correct: {representations.shape}')
 
     @pytest.mark.memory_intense
     def test_one_text_two_targets(self):
-        model = HuggingfaceSubject(model_id='distilgpt2', tokenization_method='old', region_layer_mapping={
+        model = HuggingfaceSubject(model_id='distilgpt2', region_layer_mapping={
             ArtificialSubject.RecordingTarget.language_system_left_hemisphere: 'transformer.h.0.ln_1',
             ArtificialSubject.RecordingTarget.language_system_right_hemisphere: 'transformer.h.1.ln_1'})
         text = 'the quick brown fox'
-        logging.info(f'Running {model.identifier()} with text "{text}"')
+        _logger.info(f'Running {model.identifier()} with text "{text}"')
         model.start_neural_recording(
             recording_target=ArtificialSubject.RecordingTarget.language_system_left_hemisphere,
             recording_type=ArtificialSubject.RecordingType.fMRI)
@@ -195,4 +193,4 @@ class TestNeural:
         assert set(representations['region'].values) == {
             ArtificialSubject.RecordingTarget.language_system_left_hemisphere,
             ArtificialSubject.RecordingTarget.language_system_right_hemisphere}
-        logging.info(f'representation shape is correct: {representations.shape}')
+        _logger.info(f'representation shape is correct: {representations.shape}')


### PR DESCRIPTION
For parts `0..1715` of the `Futrell2018` stimuli, the model wrapper would use the `_tokenize_older_tokenizers` as expected. For part `1716`, `_tokenize_newer_tokenizers` runs successfully and messes up the downstream cross entropy computation. This PR changes the choice of tokenize method to depend on only the tokenizer class instead of first trying the new method and then falling back to the old method; thereby keeping the choice of method stable.

also add method hints and use a fixed `device` instead of checking for cuda every time.