### PR TITLE
Only run plugin tests for new or modified plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
 env:
   global:
     - PYTEST_SETTINGS="not requires_gpu and not memory_intense and not slow and not travis_slow"
-    - CHANGES_PLUGINS="false"
 install:
   - python -m pip install -e ".[test]"
   # install conda for plugin runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
 env:
   global:
     - PYTEST_SETTINGS="not requires_gpu and not memory_intense and not slow and not travis_slow"
+    - CHANGES_PLUGINS="false"
 install:
   - python -m pip install -e ".[test]"
   # install conda for plugin runner
@@ -30,7 +31,8 @@ install:
 script:
   - if [ "$PRIVATE_ACCESS" = 1 ] && [ -n "${GITHUB_TOKEN}" ]; then pytest -m "private_access and $PYTEST_SETTINGS"; fi
   - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and $PYTEST_SETTINGS" --ignore "tests/test_submission"; fi
-  - python -c "from brainscore_core.plugin_management.test_plugins import run_args; run_args('brainscore_language')"
+  # if plugin files added or modified, run tests for those plugins
+  - if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then python -c "from brainscore_core.plugin_management.parse_plugin_changes import run_changed_plugin_tests; run_changed_plugin_tests($TRAVIS_PULL_REQUEST_SHA, 'brainscore_language')"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - if [ "$PRIVATE_ACCESS" = 1 ] && [ -n "${GITHUB_TOKEN}" ]; then pytest -m "private_access and $PYTEST_SETTINGS"; fi
   - if [ "$PRIVATE_ACCESS" != 1 ]; then pytest -m "not private_access and $PYTEST_SETTINGS" --ignore "tests/test_submission"; fi
   # if plugin files added or modified, run tests for those plugins
-  - if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then python -c "from brainscore_core.plugin_management.parse_plugin_changes import run_changed_plugin_tests; run_changed_plugin_tests($TRAVIS_PULL_REQUEST_SHA, 'brainscore_language')"
+  - if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then python -c "from brainscore_core.plugin_management.parse_plugin_changes import run_changed_plugin_tests; run_changed_plugin_tests($TRAVIS_PULL_REQUEST_SHA, 'brainscore_language')"; fi
 
 jobs:
   include:


### PR DESCRIPTION
[Depends on [core PR #36](https://github.com/brain-score/core/pull/36)]

In the interest of reducing burdensome test time, this moves from running all tests on Travis for every plugin on every PR to only running tests for plugins added or modified by the PR on Travis.

The gap in test coverage introduced by this PR is intended to be closed by instead having each PR initiate a non-blocking Jenkins run for all plugin and integration tests (possibly in conjunction with Issue #172).

Note: [parse_plugin_changes.py](https://github.com/brain-score/core/blob/503c52e4668e40ab27fd649a06d3daf5fa8d6839/brainscore_core/plugin_management/parse_plugin_changes.py) will replace [parse_changed_files.py](https://github.com/brain-score/language/blob/main/.github/workflows/parse_changed_files.py).