### PR TITLE
Fixed minor device mapping bug with HuggingfaceSubject

### DIFF
--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -244,6 +244,7 @@ class HuggingfaceSubject(ArtificialSubject):
         actual_tokens = self.current_tokens['input_ids'].squeeze(dim=0).contiguous()
         if actual_tokens.shape[0] == predicted_logits.shape[0] + 1:  # multiple tokens for first model input
             actual_tokens = actual_tokens[1:]  # we have no prior context to predict the 0th token
+        actual_tokens = actual_tokens.to(self.device)
 
         # assume that reading time is additive, i.e. reading time of multiple tokens is
         # the sum of the surprisals of each individual token.


### PR DESCRIPTION
Previously, running `score` on a Huggingface model on a GPU-enabled device produced a bug where the benchmark tokens would be loaded onto the CPU, while the model-predicted tokens would be on GPU, leading to the following Runtime Error when computing the cross entropy loss:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument target in method wrapper_CUDA_nll_loss_forward)
```

This PR addresses this by loading the actual tokens on the same device as the predicted tokens.