### PR TITLE
Ks/refactor scoring endpoint

### DIFF
--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -2,7 +2,7 @@ from typing import List, Union, Dict
 
 from brainscore_core import Score, Benchmark
 from brainscore_core.submission import RunScoringEndpoint, DomainPlugins
-from brainscore_core.submission.endpoints import make_argparser, retrieve_models_and_benchmarks, resolve_models, resolve_benchmarks, get_user_id, \
+from brainscore_core.submission.endpoints import make_argparser, resolve_models_benchmarks, get_user_id, \
     send_email_to_submitter as send_email_to_submitter_core
 from brainscore_language import load_model, load_benchmark, score
 from brainscore_language.submission import config
@@ -24,7 +24,7 @@ run_scoring_endpoint = RunScoringEndpoint(language_plugins, db_secret=config.get
 
 
 def run_scoring(args_dict: Dict[str, Union[str, List]]):
-    model_ids, benchmark_ids = resolve_models_benchmarks(args_dict)
+    model_ids, benchmark_ids = resolve_models_benchmarks(domain="language", args_dict=args_dict)
     
     for benchmark in benchmark_ids:
         for model in model_ids:
@@ -33,14 +33,6 @@ def run_scoring(args_dict: Dict[str, Union[str, List]]):
                                 user_id=args_dict["user_id"], model_type="artificialsubject",
                                 public=args_dict["public"], competition=args_dict["competition"])
 
-def resolve_models_benchmarks(args_dict: Dict[str, Union[str, List]]):
-    benchmarks, models = retrieve_models_and_benchmarks(args_dict)
-
-    model_ids = resolve_models(domain="language", models=models)
-    benchmark_ids = resolve_benchmarks(domain="language", benchmarks=benchmarks)
-    print("BS_NEW_MODELS=" + " ".join(model_ids))
-    print("BS_NEW_BENCHMARKS=" + " ".join(benchmark_ids))
-    return model_ids, benchmark_ids
 
 def send_email_to_submitter(uid: int, domain: str, pr_number: str,
                             mail_username: str, mail_password: str):
@@ -62,6 +54,6 @@ if __name__ == '__main__':
     if args.fn == 'run_scoring':
         run_scoring(args_dict)
     elif args.fn == 'resolve_models_benchmarks':
-        resolve_models_benchmarks(args_dict)
+        resolve_models_benchmarks(domain="language", args_dict=args_dict)
     else:
         raise ValueError(f'Invalid method: {args.fn}')

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -25,13 +25,14 @@ run_scoring_endpoint = RunScoringEndpoint(language_plugins, db_secret=config.get
 
 def run_scoring(args_dict: Dict[str, Union[str, List]]):
     benchmarks, models = retrieve_models_and_benchmarks(args_dict)
-
-    run_scoring_endpoint(domain="language", jenkins_id=args_dict["jenkins_id"],
-                         models=models, benchmarks=benchmarks, user_id=args_dict["user_id"],
-                         model_type="artificialsubject", public=args_dict["public"],
-                         competition=args_dict["competition"])
-
-
+    
+    for benchmark in benchmarks:
+        for model in models:
+            run_scoring_endpoint(domain="language", jenkins_id=args_dict["jenkins_id"],
+                                model_identifier=model, benchmark_identifier=benchmark,
+                                user_id=args_dict["user_id"], model_type="artificialsubject",
+                                public=args_dict["public"], competition=args_dict["competition"])
+    
 def send_email_to_submitter(uid: int, domain: str, pr_number: str,
                             mail_username: str, mail_password: str):
     send_email_to_submitter_core(uid=uid, domain=domain, pr_number=pr_number,
@@ -47,5 +48,12 @@ if __name__ == '__main__':
     if 'user_id' not in args_dict or args_dict['user_id'] is None:
         user_id = get_user_id(args_dict['author_email'], db_secret=config.get_database_secret())
         args_dict['user_id'] = user_id
-
-    run_scoring(args_dict)
+    
+    if args.fn == 'run_scoring':
+        run_scoring(args_dict)
+    elif args.fn == 'get_models_and_benchmarks':
+        benchmark_ids, model_ids = retrieve_models_and_benchmarks(args_dict)
+        print("BS_NEW_MODELS=" + " ".join(model_ids))
+        print("BS_NEW_BENCHMARKS=" + " ".join(benchmark_ids))
+    else:
+        raise ValueError(f'Invalid method: {args.fn}')

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -42,6 +42,10 @@ def send_email_to_submitter(uid: int, domain: str, pr_number: str,
 
 if __name__ == '__main__':
     parser = make_argparser()
+    parser.add_argument('--fn', type=str, nargs='?', default='run_scoring',
+                    choices=['run_scoring', 'retrieve_models_and_benchmarks'],
+                    help='The endpoint method to run. `run_scoring` to score `new_models` on `new_benchmarks`, or `get_models_and_benchmarks` to respond with a list of models and benchmarks to score.')
+
     args, remaining_args = parser.parse_known_args()
     args_dict = vars(args)
 
@@ -51,7 +55,7 @@ if __name__ == '__main__':
     
     if args.fn == 'run_scoring':
         run_scoring(args_dict)
-    elif args.fn == 'get_models_and_benchmarks':
+    elif args.fn == 'retrieve_models_and_benchmarks':
         benchmark_ids, model_ids = retrieve_models_and_benchmarks(args_dict)
         print("BS_NEW_MODELS=" + " ".join(model_ids))
         print("BS_NEW_BENCHMARKS=" + " ".join(benchmark_ids))

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -52,8 +52,8 @@ def send_email_to_submitter(uid: int, domain: str, pr_number: str,
 if __name__ == '__main__':
     parser = make_argparser()
     parser.add_argument('--fn', type=str, nargs='?', default='run_scoring',
-                    choices=['run_scoring', 'retrieve_models_and_benchmarks'],
-                    help='The endpoint method to run. `run_scoring` to score `new_models` on `new_benchmarks`, or `retrieve_models_and_benchmarks` to respond with a list of models and benchmarks to score.')
+                    choices=['run_scoring', 'resolve_models_benchmarks'],
+                    help='The endpoint method to run. `run_scoring` to score `new_models` on `new_benchmarks`, or `resolve_models_benchmarks` to respond with a list of models and benchmarks to score.')
 
     args, remaining_args = parser.parse_known_args()
     args_dict = vars(args)
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     
     if args.fn == 'run_scoring':
         run_scoring(args_dict)
-    elif args.fn == 'retrieve_models_and_benchmarks':
-        retrieve_models_and_benchmarks(args_dict)
+    elif args.fn == 'resolve_models_benchmarks':
+        resolve_models_benchmarks(args_dict)
     else:
         raise ValueError(f'Invalid method: {args.fn}')

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -51,9 +51,6 @@ def send_email_to_submitter(uid: int, domain: str, pr_number: str,
 
 if __name__ == '__main__':
     parser = make_argparser()
-    parser.add_argument('--fn', type=str, nargs='?', default='run_scoring',
-                    choices=['run_scoring', 'resolve_models_benchmarks'],
-                    help='The endpoint method to run. `run_scoring` to score `new_models` on `new_benchmarks`, or `resolve_models_benchmarks` to respond with a list of models and benchmarks to score.')
 
     args, remaining_args = parser.parse_known_args()
     args_dict = vars(args)

--- a/brainscore_language/submission/endpoints.py
+++ b/brainscore_language/submission/endpoints.py
@@ -36,8 +36,8 @@ def run_scoring(args_dict: Dict[str, Union[str, List]]):
 def resolve_models_benchmarks(args_dict: Dict[str, Union[str, List]]):
     benchmarks, models = retrieve_models_and_benchmarks(args_dict)
 
-    model_ids = resolve_models(models)
-    benchmark_ids = resolve_benchmarks(benchmarks)
+    model_ids = resolve_models(domain="language", models=models)
+    benchmark_ids = resolve_benchmarks(domain="language", benchmarks=benchmarks)
     print("BS_NEW_MODELS=" + " ".join(model_ids))
     print("BS_NEW_BENCHMARKS=" + " ".join(benchmark_ids))
     return model_ids, benchmark_ids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.7"
 dependencies = [
     "tqdm",
     "numpy>=1.21",
-    "brainscore_core@git+https://github.com/shehadak/core.git@main",
+    "brainscore_core@git+https://github.com/brain-score/core.git@main",
     "fire",
     "scikit-learn",
     # model_helpers dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.7"
 dependencies = [
     "tqdm",
     "numpy>=1.21",
-    "brainscore_core@git+https://github.com/brain-score/core.git@main",
+    "brainscore_core@git+https://github.com/shehadak/core.git@main",
     "fire",
     "scikit-learn",
     # model_helpers dependencies

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import subprocess
 import sys
@@ -50,6 +51,30 @@ from brainscore_language import score
 )
 def test_score(model_identifier, benchmark_identifier, expected_score):
     actual_score = score(model_identifier=model_identifier, benchmark_identifier=benchmark_identifier)
+    assert actual_score == expected_score
+
+
+@pytest.mark.parametrize(
+    "model_identifier, benchmark_identifier, expected_score, install_dependencies",
+    [
+        ("randomembedding-100", "Pereira2018.243sentences-linear",
+         approx(0.0285022, abs=0.0005), "newenv"),
+        ("randomembedding-100", "Pereira2018.243sentences-linear",
+         approx(0.0285022, abs=0.0005), "yes"),
+        ("randomembedding-100", "Pereira2018.243sentences-linear",
+         approx(0.0285022, abs=0.0005), "no"),
+    ]
+)
+def test_score_with_install_dependencies(
+        model_identifier, benchmark_identifier, expected_score, install_dependencies):
+    install_dependence_preference = os.environ.get(
+        "BS_INSTALL_DEPENDENCIES", "yes")
+    os.environ["BS_INSTALL_DEPENDENCIES"] = install_dependencies
+    actual_score = score(
+        model_identifier=model_identifier,
+        benchmark_identifier=benchmark_identifier,
+        conda_active=True)
+    os.environ["BS_INSTALL_DEPENDENCIES"] = install_dependence_preference
     assert actual_score == expected_score
 
 

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -38,7 +38,7 @@ class TestRunScoring:
         args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 
                     'public': True, 'competition': 'None', 'new_models': new_models, 
                     'new_benchmarks': new_benchmarks, 'specified_only': True}
-        model_ids, benchmark_ids = retrieve_models_and_benchmarks(args_dict)
+        benchmark_ids, model_ids = retrieve_models_and_benchmarks(args_dict)
         assert model_ids == new_models
         assert benchmark_ids == new_benchmarks
         

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -6,10 +6,10 @@ from pytest import approx
 """ the mock import has to be before importing endpoints so that the database is properly mocked """
 from .mock_config import test_database
 
-from brainscore_core.submission import database_models, RunScoringEndpoint
+from brainscore_core.submission import database_models
 from brainscore_core.submission.database import connect_db
 from brainscore_core.submission.database_models import clear_schema
-from brainscore_language.submission.endpoints import run_scoring, get_models_and_benchmarks
+from brainscore_language.submission.endpoints import run_scoring, retrieve_models_and_benchmarks
 
 
 logger = logging.getLogger(__name__)
@@ -32,13 +32,13 @@ class TestRunScoring:
         logger.info('Clean database')
         clear_schema()
 
-    def test_get_models_benchmarks(self):
+    def test_retrieve_models_and_benchmarks(self):
         new_models = ['randomembedding-100']
         new_benchmarks = ['Pereira2018.243sentences-linear']
         args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 
                     'public': True, 'competition': 'None', 'new_models': new_models, 
                     'new_benchmarks': new_benchmarks, 'specified_only': True}
-        model_ids, benchmark_ids = get_models_and_benchmarks(args_dict)
+        model_ids, benchmark_ids = retrieve_models_and_benchmarks(args_dict)
         assert model_ids == new_models
         assert benchmark_ids == new_benchmarks
         

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -9,7 +9,7 @@ from .mock_config import test_database
 from brainscore_core.submission import database_models
 from brainscore_core.submission.database import connect_db
 from brainscore_core.submission.database_models import clear_schema
-from brainscore_language.submission.endpoints import run_scoring, retrieve_models_and_benchmarks
+from brainscore_language.submission.endpoints import run_scoring
 
 
 logger = logging.getLogger(__name__)
@@ -31,16 +31,6 @@ class TestRunScoring:
     def teardown_method(self):
         logger.info('Clean database')
         clear_schema()
-
-    def test_retrieve_models_and_benchmarks(self):
-        new_models = ['randomembedding-100']
-        new_benchmarks = ['Pereira2018.243sentences-linear']
-        args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 
-                    'public': True, 'competition': 'None', 'new_models': new_models, 
-                    'new_benchmarks': new_benchmarks, 'specified_only': True}
-        benchmark_ids, model_ids = retrieve_models_and_benchmarks(args_dict)
-        assert model_ids == new_models
-        assert benchmark_ids == new_benchmarks
         
     def test_successful_run(self):
         args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -6,10 +6,10 @@ from pytest import approx
 """ the mock import has to be before importing endpoints so that the database is properly mocked """
 from .mock_config import test_database
 
-from brainscore_core.submission import database_models
+from brainscore_core.submission import database_models, RunScoringEndpoint
 from brainscore_core.submission.database import connect_db
 from brainscore_core.submission.database_models import clear_schema
-from brainscore_language.submission.endpoints import run_scoring
+from brainscore_language.submission.endpoints import run_scoring, get_models_and_benchmarks
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +32,16 @@ class TestRunScoring:
         logger.info('Clean database')
         clear_schema()
 
+    def test_get_models_benchmarks(self):
+        new_models = ['randomembedding-100']
+        new_benchmarks = ['Pereira2018.243sentences-linear']
+        args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 
+                    'public': True, 'competition': 'None', 'new_models': new_models, 
+                    'new_benchmarks': new_benchmarks, 'specified_only': True}
+        model_ids, benchmark_ids = get_models_and_benchmarks(args_dict)
+        assert model_ids == new_models
+        assert benchmark_ids == new_benchmarks
+        
     def test_successful_run(self):
         args_dict = {'jenkins_id': 62, 'user_id': 1, 'model_type': 'artificialsubject', 
                     'public': True, 'competition': 'None', 'new_models': ['randomembedding-100'], 


### PR DESCRIPTION
This PR separates the functionality of the language submission endpoint into two separate methods: `run_score`, which calls the core scoring endpoint on every model/benchmark pair provided, and `get_models_and_benchmarks` which provides a list of model/benchmark pairs for scoring given a list of new models and new benchmarks. Previously, both functionalities were included in the `run_score` method. However, motivated by the need to run scoring jobs on multiple nodes in an HPC instead of in a single job, this PR enables scripts to separately identify the list of model/benchmark pairs and run calls to the core scoring endpoint.

This PR is complementary to [https://github.com/brain-score/core/pull/40](https://github.com/brain-score/core/pull/40)

**A note on backward compatibility:** While this PR modifies `run_scoring` into two separate methods, the default functionality is still the same. In particular, if a user does not specify `--fn=get_models_and_benchmarks`, the `run_scoring` method will be called, which is the expected functionality prior to this PR.

**A note on `pyproject.toml`:** The commit `aa21570` is for debugging purposes and will be reverted before merging.