### PR TITLE
Prevent triggering Travis plugin tests for empty git diff results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ before_script:
   - git fetch --depth=50 origin refs/heads/main:refs/heads/main
 script:
   # if ONLY plugin files changed, ONLY run tests for those plugins; otherwise, run full test suite
-  - CHANGED_FILES=$( echo $(git diff --name-only main $TRAVIS_PULL_REQUEST_SHA -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' )
   - |
-    if [ "$TRAVIS_PULL_REQUEST" ]; then 
+    if [ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then 
+      CHANGED_FILES=$( git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch && echo $(git diff --name-only origin/$TRAVIS_PULL_REQUEST_BRANCH origin/$TRAVIS_BRANCH -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
       TESTING_NEEDED=$( python -c "from brainscore_core.plugin_management.parse_plugin_changes import get_testing_info; get_testing_info(\"${CHANGED_FILES}\", 'brainscore_language')" ) && 
       read MODIFIES_PLUGIN PLUGIN_ONLY <<< $TESTING_NEEDED && echo MODIFIES_PLUGIN: $MODIFIES_PLUGIN && echo PLUGIN_ONLY: $PLUGIN_ONLY; 
     fi


### PR DESCRIPTION
Only attempt git diff to get changed files if $TRAVIS_PULL_REQUEST_BRANCH is not empty. Prevents triggering plugin tests for empty diff results.