### PR TITLE
Set `score_new_plugins` GitHub Action python version to 3.9

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -23,7 +23,11 @@ jobs:
       BSC_DATABASESECRET: ${{ steps.setenvvars.outputs.BSC_DATABASESECRET }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
       - name: Check if main & set dev/prod vars
         id: setenvvars
         run: |


### PR DESCRIPTION
Avoids `site-packages` installation issue (`Defaulting to user installation because normal site-packages is not writeable`).  