### PR TITLE
Fixed various bugs in the 'score_new_plugins' workflow

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -53,14 +53,22 @@ jobs:
           fetch-depth: 0
 
       - name: Save changed files to env var
-        run: echo "CHANGED_FILES=$(git diff --name-only origin/main origin/$GITHUB_HEAD_REF | tr '\n' ' ')"  >> $GITHUB_ENV
+        run: echo "CHANGED_FILES=$(git diff --name-only origin/main~1 origin/$GITHUB_HEAD_REF | tr '\n' ' ')"  >> $GITHUB_ENV
         
-      - name: Get scoring info
+      - name: Installing package dependencies
         run: |
-          python -m pip install .
-          echo "PLUGIN_INFO=$(python -c 'from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info("${{ env.CHANGED_FILES }}", "brainscore_language")')"  >> $GITHUB_OUTPUT  
-          echo "RUN_SCORE=$(jq -r '.run_score' <<< "$PLUGIN_INFO")" >> $GITHUB_OUTPUT
-
+          python -m pip install --upgrade pip setuptools
+          python -m pip install ".[test]"
+      
+      - name: Get plugin info
+        id: getpluginfo
+        run: |
+          echo "PLUGIN_INFO='$(python -c 'from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info("${{ env.CHANGED_FILES }}", "brainscore_language")')'"  >> $GITHUB_OUTPUT
+      
+      - name: Run scoring
+        id: runscore
+        run: |
+          echo "RUN_SCORE=$(jq -r '.run_score' <<< ${{ steps.getpluginfo.outputs.PLUGIN_INFO }})" >> $GITHUB_OUTPUT
 
   get_submitter_info:
     name: Get PR author email and (if web submission) Brain-Score user ID
@@ -95,7 +103,7 @@ jobs:
         id: add_email_to_pluginfo
         run: |
           echo "The PR author email is ${{ steps.getemail.outputs.email }}"
-          echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {author_email: "'${{ steps.getemail.outputs.email }}'"}')"" >> $GITHUB_OUTPUT
+          echo "PLUGIN_INFO=$(<<<$PLUGIN_INFO tr -d "'"  | jq -c '. + {author_email: "${{ steps.getemail.outputs.email }}"}')" >> $GITHUB_OUTPUT
 
 
   runscore:
@@ -111,12 +119,13 @@ jobs:
     steps:
       - name: Add public, competition, and model_type to PLUGIN_INFO
         run: |
-          echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {domain: "language", public: "True", competition: "None", model_type: "artificialsubject"}')"" >> $GITHUB_ENV
+          echo "PLUGIN_INFO=$(<<<$PLUGIN_INFO tr -d "'"  | jq -c '. + {domain: "language", public: true, competition: "None", model_type: "artificialsubject"}')" >> $GITHUB_ENV
 
       - name: Check out repository code
         uses: actions/checkout@v2
 
       - name: Build project and run scoring
         run: |
-          python -m pip install "."
-          python -c "from brainscore_core.submission.endpoints import call_jenkins; call_jenkins('$env.PLUGIN_INFO')"
+          python -m pip install --upgrade pip setuptools
+          python -m pip install ".[test]"
+          python -c 'from brainscore_core.submission.endpoints import call_jenkins; call_jenkins('\''${{ env.PLUGIN_INFO }}'\'')'


### PR DESCRIPTION

### Changes
This PR addresses multiple issues in the current `score_new_plugins` workflow:

1. Since the flow runs _after_ the merge, `git diff --name-only origin/main origin/$GITHUB_HEAD_REF` will almost always be empty if the merged branch was rebased correctly because it will be equivalent to `main`. Therefore, referencing the second-to-last commit in `main`, which does not include the merge updates.
2. The default `pip` does not correctly install dependencies using `pyproject.toml` following [this bug report](https://github.com/pypa/setuptools/issues/3269). Updating `pip` and `setuptools` prior to installing the project resolves this.
3. I separated certain functionality into different steps, each with its corresponding `id`, in order to be consistent with the `outputs` and `needs` specifications.
4. I fixed a few syntax problems with quotation and parentheses inconsistencies, and I ensured input and output adhered to JSON format.

### Testing
TBD

**P.S.:** this PR depends on [Core PR #54](https://github.com/brain-score/core/pull/54) and should not be merged until that is resolved.