### PR TITLE
added .eval() to HuggingfaceSubject

### DIFF
--- a/brainscore_language/model_helpers/huggingface.py
+++ b/brainscore_language/model_helpers/huggingface.py
@@ -58,6 +58,7 @@ class HuggingfaceSubject(ArtificialSubject):
             ArtificialSubject.Task.reading_times: self.estimate_reading_times,
         }
         self.task_function_mapping_dict = {**task_mapping_default, **task_heads} if task_heads else task_mapping_default
+        self.basemodel.eval()
 
     def identifier(self):
         return self.model_id


### PR DESCRIPTION
Enabled evaluation mode for HF models before passing stimuli. This disables dropout and changes normalisation layers (e.g. BatchNorm) to use averages computed during training. I computed brain alignment with and without `.eval()` and the results are different!

In the future there needs to be a `_PytorchTransformerWrapper` like here to enable eval for any PyTorch model and not only HF models: https://github.com/mschrimpf/neural-nlp/blob/6e1a989b24fff0ffd7cac67d880a94136c4b4fb5/neural_nlp/models/implementations.py#L686