### PR TITLE
Fixed minor issues with travis scripts and a typo with automerge workflow

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -68,7 +68,7 @@ jobs:
         id: gettravisstatus
         run: |
           echo ${{ github.event.pull_request.head.sha }}
-          echo "TRAVIS_CONCLUSION=$(python -c "import requests; r = requests.get(\"https://api.github.com/repos/brain-score/language/commits/$github.event.pull_request.head.sha/check-runs\"); print(next(run['conclusion'] for run in r.json()['check_runs'] if run['name'] == 'Travis CI - Pull Request'))")" >> $GITHUB_ENV
+          echo "TRAVIS_CONCLUSION=$(python -c "import requests; r = requests.get(\"https://api.github.com/repos/brain-score/language/commits/${{ github.event.pull_request.head.sha }}/check-runs\"); print(next(run['conclusion'] for run in r.json()['check_runs'] if run['name'] == 'Travis CI - Pull Request'))")" >> $GITHUB_ENV
       - name: Check if Travis was successful
         id: istravisok
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,11 @@ jobs:
     - stage: "Automerge check"
       install: skip
       if: type = pull_request
-      script: if [ "$PLUGIN_ONLY" = "True" ]; then bash ${TRAVIS_BUILD_DIR}/.github/workflows/travis_trigger.sh $GH_WORKFLOW_TRIGGER $TRAVIS_PULL_REQUEST_SHA $PLUGIN_ONLY; fi
+      script: 
+        - |
+          if [ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then 
+            CHANGED_FILES=$( git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch && echo $(git diff --name-only origin/$TRAVIS_PULL_REQUEST_BRANCH origin/$TRAVIS_BRANCH -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
+            TESTING_NEEDED=$( python -c "from brainscore_core.plugin_management.parse_plugin_changes import get_testing_info; get_testing_info(\"${CHANGED_FILES}\", 'brainscore_language')" ) && 
+            read MODIFIES_PLUGIN PLUGIN_ONLY <<< $TESTING_NEEDED && echo MODIFIES_PLUGIN: $MODIFIES_PLUGIN && echo PLUGIN_ONLY: $PLUGIN_ONLY; 
+          fi
+        - if [ "$PLUGIN_ONLY" = "True" ]; then bash ${TRAVIS_BUILD_DIR}/.github/workflows/travis_trigger.sh $GH_WORKFLOW_TRIGGER $TRAVIS_PULL_REQUEST_SHA $PLUGIN_ONLY; fi


### PR DESCRIPTION
This PR fixes two issues with the current auto-merging pipeline:
1. A typo in `.github/workflows/automerge_plugin-only_prs.yml`. The term `$github.event.pull_request.head.sha/check-runs\` does not get evaluated in the current script, so I replaced it with `${{ github.event.pull_request.head.sha }}`.
2. The `script` block in the last job in Travis overrides the top-level `script` block, so `$PLUGIN_ONLY` will always be `False` as defined in the `env` block. This PR fixes this by copying the script that evaluates `$PLUGIN_ONLY` to the `script` block of the last Travis job.