### PR TITLE
Allow data additions in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ __pycache__/
 
 # Folders
 xarray_test/*
-data/*
 
 # C extensions
 *.so
@@ -136,7 +135,6 @@ dmypy.json
 
 ### project specific additions:
 
-brainscore_language/data
 html
 .vscode
 *.code-workspace
@@ -149,4 +147,3 @@ cache
 .cache
 .idea/
 wandb/
-**/models/lm1b/resources


### PR DESCRIPTION
for some reason, `brainscore_language/data` was excluded but we of course welcome data submissions