### PR TITLE
Update tests to use new schema 

### DIFF
--- a/tests/test_submission/mock_config.py
+++ b/tests/test_submission/mock_config.py
@@ -1,3 +1,3 @@
 from brainscore_language.submission import config
-test_database = 'brainscore-ohio-test'
+test_database = 'brainscore-ohio-test_language'
 config.get_database_secret = lambda: test_database

--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -8,7 +8,7 @@ from .mock_config import test_database
 
 from brainscore_core.submission import database_models
 from brainscore_core.submission.database import connect_db
-from brainscore_core.submission.database_models import clear_schema
+from brainscore_core.submission.database_models import clear_schema, database_proxy, PeeweeBase, create_tables
 from brainscore_language.submission.endpoints import run_scoring
 
 
@@ -21,7 +21,14 @@ class TestRunScoring:
     def setup_class(cls):
         logger.info('Connect to database')
         connect_db(test_database)
-        clear_schema()
+        
+        # Drop old tables and recreate with current schema (only for test databases)
+        if 'test' in test_database.lower():
+            logger.info('Dropping and recreating tables with updated schema')
+            database_proxy.drop_tables(PeeweeBase.__subclasses__(), safe=True, cascade=True)
+            create_tables()
+        
+        clear_schema()  # Clear any data from previous runs
 
     def setup_method(self):
         logger.info('Initialize database entries')


### PR DESCRIPTION
This PR:

1. Uses the new language testing db (instead of sharing with vision)
2. Forces that db to create the new post-meta data schemas on test init
