### PR TITLE
Checkout PR branch

### DIFF
--- a/.github/workflows/plugin_submission_orchestrator.yml
+++ b/.github/workflows/plugin_submission_orchestrator.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
           fetch-depth: 0
 
       - name: Set up Python


### PR DESCRIPTION
Previously, Step 1 checked out the default branch (main) instead of the PR branch. This worked fine when committing to currently open PRs but failed when opening a fresh PR. 