### PR TITLE
Fix localizer multi-GPU failure (model.to vs device_map)

### DIFF
--- a/brainscore_language/model_helpers/localize.py
+++ b/brainscore_language/model_helpers/localize.py
@@ -106,7 +106,8 @@ def extract_representations(
     logger.debug(f"> Using Device: {device}")
 
     model.eval()
-    model.to(device)
+    if not getattr(model, "hf_device_map", None):  # skip when already sharded via device_map
+        model.to(device)
 
     final_layer_representations = {
         "sentences": {layer_name: np.zeros((len(langloc_dataset.sentences), hidden_dim)) for layer_name in layer_names},


### PR DESCRIPTION
On multi-GPU scoring tiers, `HuggingfaceSubject` loads models with `device_map='auto'` (sharded across GPUs). The localizer's `extract_representations` then called `model.to(device)`, which tries to consolidate the sharded model onto a single GPU:

- **8B** (fp32 ~32GB): OOMs trying to move the whole model onto one ~22GB A10G.
- **4B**: partial consolidation leaves layers split, then the forward pass raises `RuntimeError: Expected all tensors to be on the same device (cuda:0 and cuda:1)`.

Both surfaced as scoring failures on the 4-GPU medium tier (jenkins run 190); 0.6B/1.7B were unaffected because they land on the single-GPU small tier (no `device_map`, so the `.to()` is a no-op).

Fix: skip `model.to(device)` when the model is already dispatched via `device_map` (`hf_device_map` set). Inputs are already sent to `self.device` (the input-embedding shard), so the sharded forward works and 8B can use all GPUs instead of OOMing on one. Single-GPU loads are unchanged.