### PR TITLE
fix(deps): constrain Transformers compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pandas <3",
     # model_helpers dependencies
     "torch >=1.9.1",
-    "transformers >=4.11.3",
+    "transformers >=4.51,<5",
     "gensim",
     "joblib",
     # submission dependencies


### PR DESCRIPTION
## Summary

- require Transformers 4.51 or newer for DynamicCache and Qwen3 support
- exclude Transformers 5, which removed the cache conversion APIs
- keep Hugging Face Hub below 1.0 through the Transformers 4 dependency range so datasets 2.x remains compatible

## Testing

- resolved the Linux Python 3.11 dependency graph to Transformers 4.57.6 and Hugging Face Hub 0.36.2
- built the wheel and verified Requires-Dist: transformers<5,>=4.51