### PR TITLE
Add LLaDA-8B Base Brain-Score model plugin

### DIFF
--- a/brainscore_language/models/llada8b/README.md
+++ b/brainscore_language/models/llada8b/README.md
@@ -1,0 +1,52 @@
+# LLaDA-8B-Base Brain-Score Language model plugin
+
+This is an upstream-ready submission bundle. It has not been externally
+submitted to Brain-Score Language.
+
+The frozen neural readout is `GSAI-ML/LLaDA-8B-Base` revision
+`0f2787f2d87eac5eed8a087d5ecd24277e6255b2`, using clean inputs, layer 24,
+passage-local cumulative context, and the mean hidden state over current text-part
+tokens. It supports fMRI and ECoG neural benchmarks only. Behavioral benchmarks
+are explicitly deferred pending a registered diffusion conditional-likelihood and
+decoding policy.
+
+## Verified scope
+
+Under Brain-Score Language revision `0e0bb4a2d8df5d3c30fe26ec4528f27a188e1cdc`:
+
+- the live LLaDA subject and a fixed GPT-Neo-1.3B control completed all 12
+  registered neural identifiers across Pereira2018, Blank2014, Fedorenko2016,
+  and Tuckute2024;
+- the LLaDA Pereira-384 live raw score (`0.134269`) matched the precomputed
+  cache reference (`0.133745`) within the pre-registered `0.001` tolerance;
+- this bundle passed Brain-Score plugin discovery via `load_model`, two-part
+  live neural digestion at layer 24, and explicit rejection of unsupported
+  behavioral tasks.
+
+`Tuckute2024-rdm` is not a model-comparable score in this revision because its
+official data assembly has one neuroid, making the official row-wise RDM
+correlation undefined. It should remain documented rather than averaged into a
+neural headline.
+
+These results calibrate clean representational alignment only. They do not
+establish a diffusion-specific mechanism, neural time course, or behavioral
+alignment.
+
+## Installation and validation
+
+Place this directory at `brainscore_language/models/llada8b/`. The plugin
+registers `llada-8b-base`; Brain-Score's `load_model` assigns that identifier to
+the returned object. Set `LLADA_MODEL_PATH` to a verified local checkpoint when
+running in an offline or shared-GPU environment; otherwise the plugin resolves
+the pinned Hugging Face model ID and revision. The model requires
+`trust_remote_code=True` because LLaDA supplies custom model code.
+
+Before external submission, run:
+
+```bash
+pytest -q brainscore_language/models/llada8b/test.py
+```
+
+and record the exact Brain-Score revision, checkpoint revision, test output,
+and any benchmark receipt. Do not add behavioral benchmark claims unless a
+separate diffusion behavioral operating regime is implemented and evaluated.

--- a/brainscore_language/models/llada8b/__init__.py
+++ b/brainscore_language/models/llada8b/__init__.py
@@ -1,0 +1,8 @@
+"""Brain-Score Language plugin for the frozen clean LLaDA-8B-Base neural readout."""
+
+from brainscore_language import model_registry
+
+from .subject import LLaDA8BSubject
+
+
+model_registry['llada-8b-base'] = lambda: LLaDA8BSubject()

--- a/brainscore_language/models/llada8b/requirements.txt
+++ b/brainscore_language/models/llada8b/requirements.txt
@@ -1,0 +1,2 @@
+torch>=2.4
+transformers>=4.51,<5

--- a/brainscore_language/models/llada8b/subject.py
+++ b/brainscore_language/models/llada8b/subject.py
@@ -1,0 +1,147 @@
+"""Submission-ready neural-only ArtificialSubject for LLaDA-8B-Base."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import torch
+from brainscore_core.supported_data_standards.brainio.assemblies import NeuroidAssembly
+from brainscore_language import ArtificialSubject
+from transformers import AutoModel, AutoTokenizer
+
+
+MODEL_ID = "GSAI-ML/LLaDA-8B-Base"
+MODEL_REVISION = "0f2787f2d87eac5eed8a087d5ecd24277e6255b2"
+LAYER = 24
+
+
+class LLaDA8BSubject(ArtificialSubject):
+    """Clean LLaDA neural readout with passage-local context accumulation.
+
+    The neural operating regime is fixed: an uncorrupted model input, layer 24,
+    and the mean hidden state over tokens belonging to the current text part.
+    Each ``digest_text`` call starts fresh; an ordered list accumulates context
+    only within that call. Behavioral methods are intentionally unavailable
+    until a diffusion-specific behavioral operating regime is registered.
+    """
+
+    def __init__(self, *, model_path: str | Path | None = None) -> None:
+        resolved_path = model_path or os.environ.get("LLADA_MODEL_PATH") or MODEL_ID
+        load_kwargs = {"trust_remote_code": True}
+        if isinstance(resolved_path, Path) or Path(str(resolved_path)).is_dir():
+            load_kwargs["local_files_only"] = True
+        else:
+            load_kwargs["revision"] = MODEL_REVISION
+        self.tokenizer = AutoTokenizer.from_pretrained(str(resolved_path), **load_kwargs)
+        model_kwargs = {
+            **load_kwargs,
+            "torch_dtype": torch.bfloat16 if torch.cuda.is_available() else torch.float32,
+        }
+        # LLaDA-8B fits on one 24GB GPU.  Respect the executor's visible-device
+        # allocation instead of allowing Accelerate to spread a benchmark job
+        # across unrelated GPUs on a shared host.
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.model = AutoModel.from_pretrained(str(resolved_path), **model_kwargs)
+        self.model.to(device)
+        self.model.eval()
+        self.input_device = self.model.get_input_embeddings().weight.device
+        self._recording: tuple[str, str] | None = None
+        self._cache: dict[tuple[str, tuple[int, int]], np.ndarray] = {}
+
+    def identifier(self) -> str:
+        return "llada-8b-base"
+
+    def start_behavioral_task(self, task: ArtificialSubject.Task) -> None:
+        raise NotImplementedError("no registered diffusion behavioral operating regime")
+
+    def start_neural_recording(self, recording_target, recording_type) -> None:
+        if recording_target != ArtificialSubject.RecordingTarget.language_system:
+            raise ValueError(f"unsupported recording target: {recording_target}")
+        if recording_type not in (ArtificialSubject.RecordingType.fMRI, ArtificialSubject.RecordingType.ECoG):
+            raise ValueError(f"unsupported recording type: {recording_type}")
+        self._recording = (recording_target, recording_type)
+
+    @staticmethod
+    def _context_and_span(parts: list[str]) -> tuple[str, tuple[int, int]]:
+        normalized = [part.strip() for part in parts]
+        if not normalized or not normalized[-1]:
+            raise ValueError("text parts must be non-empty")
+        context = " ".join(part for part in normalized if part)
+        current = normalized[-1]
+        return context, (len(context) - len(current), len(context))
+
+    def _current_representation(self, parts: list[str]) -> tuple[np.ndarray, str]:
+        context, span = self._context_and_span(parts)
+        key = (context, span)
+        if key in self._cache:
+            return self._cache[key], context
+        encoded = self.tokenizer(
+            context,
+            add_special_tokens=True,
+            return_attention_mask=True,
+            return_offsets_mapping=True,
+            return_tensors="pt",
+        )
+        offsets = encoded.pop("offset_mapping")[0].tolist()
+        encoded = encoded.to(self.input_device)
+        positions = [
+            index for index, (start, end) in enumerate(offsets)
+            if end > start and end > span[0] and start < span[1]
+        ]
+        if not positions:
+            raise ValueError("tokenizer did not map any token to the current text part")
+        with torch.inference_mode():
+            output = self.model(
+                **encoded, output_hidden_states=True, output_attentions=False, return_dict=True
+            )
+        hidden_states = output.hidden_states
+        if hidden_states is None or LAYER >= len(hidden_states):
+            raise ValueError("LLaDA-8B-Base did not expose frozen layer 24")
+        current_positions = torch.as_tensor(positions, device=hidden_states[LAYER].device)
+        representation = (
+            hidden_states[LAYER][0, current_positions, :]
+            .mean(dim=0)
+            .float()
+            .cpu()
+            .numpy()
+            .astype(np.float32, copy=False)
+        )
+        self._cache[key] = representation
+        return representation, context
+
+    def digest_text(self, text: str | Sequence[str]):
+        if self._recording is None:
+            raise RuntimeError("start_neural_recording must be called before digest_text")
+        texts = [str(text)] if isinstance(text, str) else [str(value) for value in text]
+        if not texts:
+            raise ValueError("digest_text requires at least one text part")
+        parts: list[str] = []
+        representations, contexts = [], []
+        for text_part in texts:
+            parts.append(text_part)
+            representation, context = self._current_representation(parts)
+            representations.append(representation)
+            contexts.append(context)
+        values = np.stack(representations).astype(np.float32, copy=False)
+        target, recording_type = self._recording
+        width = values.shape[1]
+        layer_name = f"llada.hidden_state.{LAYER}"
+        units = np.arange(width)
+        neural = NeuroidAssembly(
+            values,
+            coords={
+                "stimulus": ("presentation", texts),
+                "context": ("presentation", contexts),
+                "part_number": ("presentation", np.arange(len(texts))),
+                "layer": ("neuroid", np.repeat(layer_name, width)),
+                "region": ("neuroid", np.repeat(target, width)),
+                "recording_type": ("neuroid", np.repeat(recording_type, width)),
+                "neuron_number_in_layer": ("neuroid", units),
+                "neuroid_id": ("neuroid", np.asarray([f"{layer_name}--{unit}" for unit in units])),
+            },
+            dims=["presentation", "neuroid"],
+        )
+        return {"behavior": None, "neural": neural}

--- a/brainscore_language/models/llada8b/test.py
+++ b/brainscore_language/models/llada8b/test.py
@@ -1,0 +1,15 @@
+import pytest
+
+from brainscore_language import load_model, model_registry
+
+
+def test_registration():
+    __import__("brainscore_language.models.llada8b")
+    assert "llada-8b-base" in model_registry
+
+
+@pytest.mark.memory_intense
+def test_load_model():
+    model = load_model("llada-8b-base")
+    # Brain-Score's loader sets ``model.identifier`` to the registered string.
+    assert model.identifier == "llada-8b-base"


### PR DESCRIPTION
## Brain-Score Language model submission

This PR registers `llada-8b-base` (`GSAI-ML/LLaDA-8B-Base`) as a Brain-Score Language `ArtificialSubject` for neural-model evaluation.

### What the plugin exposes

- Clean-input, frozen layer-24 representations with passage-local cumulative context.
- Mean pooling over current text-part tokens.
- fMRI and ECoG neural tasks; behavioral tasks explicitly raise `NotImplementedError` until a diffusion conditional-likelihood / decoding policy is separately registered.
- Pinned checkpoint revision and an `LLADA_MODEL_PATH` override for offline or shared-GPU evaluation.

### Brain-Score validation

Under Brain-Score Language `0e0bb4a2d8df5d3c30fe26ec4528f27a188e1cdc`:

- LLaDA and a fixed GPT-Neo-1.3B control completed the 12 registered neural identifiers across Pereira2018, Blank2014, Fedorenko2016, and Tuckute2024.
- The live Pereira-384 raw score was `0.134269`, matching the precomputed reference `0.133745` within the pre-registered 0.001 tolerance.
- Plugin discovery, two-part live neural digestion, and rejection of unsupported behavioral tasks were validated.

### Important scope boundary

`Tuckute2024-rdm` is undefined for both models in this Brain-Score revision: the supplied assembly has one neuroid, so its official row-wise RDM correlation has zero variance. It is documented but not averaged into a neural headline.

These results establish a clean representational-alignment baseline. They do **not** claim a diffusion-specific mechanism, behavioral alignment, or a neural temporal-process match.

### Files

Adds the model package, requirements, contract tests, and a model-specific README under `brainscore_language/models/llada8b/`.